### PR TITLE
[qa] Pin down flake8 and isort in extra_requires['qa']

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,20 @@ sudo: false
 cache: pip
 
 python:
-  - "3.4"
+  - "3.5"
   - "2.7"
 
 env:
   - DJANGO="django>=1.11,<1.12"
   - DJANGO="django>=2.0,<2.1"
+  - DJANGO="django>=2.1,<2.2"
 
 matrix:
   exclude:
     - python: "2.7"
       env: DJANGO="django>=2.0,<2.1"
+    - python: "2.7"
+      env: DJANGO="django>=2.1,<2.2"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 install:
   - pip install https://github.com/openwisp/openwisp-users/tarball/master
   - pip install $DJANGO
-  - pip install -e .[users]
+  - pip install -e .[users] .[qa]
 
 before_script:
   - ./runflake8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,5 @@
 coverage
 coveralls
-isort
-flake8
 # For testing Dependency loaders
 django_netjsonconfig
 djangorestframework>=3.8.2,<3.9

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,10 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=['django-model-utils>=3.1.2,<3.3.0'],
-    extras_require={'users': ['openwisp-users<0.2']},
+    extras_require={
+        'users': ['openwisp-users<0.2'],
+        'qa': ['flake8<=3.0.4', 'isort<=4.3.4']
+    },
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',


### PR DESCRIPTION
We will use openwisp-utils in all the other modules to pin down the flake8 and isort versions to reduce the maintenance overhead of having to update the `flake8` and `isort` versions in each OpenWISP 2 module