### PR TITLE
[qa] Improved our quality assurance checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_install:
   - pip install -U pip wheel setuptools
   - pip install --no-cache-dir -U -r requirements-test.txt
 
-# command to install requirements
 install:
   - pip install https://github.com/openwisp/openwisp-users/tarball/master
   - pip install $DJANGO
@@ -36,9 +35,16 @@ before_script:
   - ./runflake8
   - ./runisort
 
-# command to run tests, e.g. python setup.py test
 script:
   - coverage run --source=openwisp_utils runtests.py
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+      # gets commit message of last commit before pull request merge
+      COMMIT_MESSAGE=$(git log $TRAVIS_PULL_REQUEST_SHA --format=%B -n 1)
+      printf "Checking commit message:\n\n"
+      printf "$COMMIT_MESSAGE\n\n"
+      checkcommit --message "$COMMIT_MESSAGE"
+    fi
 
 after_success:
   coveralls

--- a/README.rst
+++ b/README.rst
@@ -222,6 +222,40 @@ Add ``openwisp_utils.staticfiles.DependencyFinder`` to ``TEMPLATES_LOADERS`` in 
         },
     ]
 
+Quality Assurance checks
+------------------------
+
+This package contains some common QA checks that are used the
+automated builds of different OpenWISP modules.
+
+``checkmigrations``
+~~~~~~~~~~~~~~~~~~~
+
+Ensures the latest migrations created have a human readable name.
+
+We want to avoid having many migrations named like ``0003_auto_20150410_3242.py``.
+
+This way we can reconstruct the evolution of our database schemas faster, with
+less efforts and hence less costs.
+
+Usage example::
+
+    checkmigrations --migration-path ./django_freeradius/migrations/
+
+``checkcommit``
+~~~~~~~~~~~~~~~
+
+Ensures the last commit message follows our `commit message style guidelines
+<http://openwisp.io/docs/developer/contributing.html#commit-message-style-guidelines>`_.
+
+We want to keep the commit log readable, consistent and easy to scan in order
+to make it easy to analyze the history of our modules, which is also a very
+important activity when performing maintenance.
+
+Usage example::
+
+    checkcommit --message "$(git log --format=%B -n 1)"
+
 Installing for development
 --------------------------
 

--- a/openwisp_utils/qa.py
+++ b/openwisp_utils/qa.py
@@ -6,22 +6,22 @@ import os
 import re
 
 
-def _parse_args():
+def _parse_migration_check_args():
     """
     Parse and return CLI arguments
     """
-    parser = argparse.ArgumentParser(description="Ensures migration files "
-                                     "created have a descriptive name. If "
-                                     "default name pattern is found, "
-                                     "raise exception!")
-    parser.add_argument("--migration-path",
-                        help="Path to `migrations/` folder")
-    parser.add_argument("--migrations-to-ignore",
+    parser = argparse.ArgumentParser(description='Ensures migration files '
+                                     'created have a descriptive name. If '
+                                     'default name pattern is found, '
+                                     'raise exception!')
+    parser.add_argument('--migration-path',
+                        help='Path to `migrations/` folder')
+    parser.add_argument('--migrations-to-ignore',
                         type=int,
-                        help="Number of migrations after which checking of "
-                        "migration file names should begin, say, if checking "
-                        "needs to start after `0003_auto_20150410_3242.py` "
-                        "value should be `3`")
+                        help='Number of migrations after which checking of '
+                        'migration file names should begin, say, if checking '
+                        'needs to start after `0003_auto_20150410_3242.py` '
+                        'value should be `3`')
     return parser.parse_args()
 
 
@@ -30,28 +30,28 @@ def check_migration_name():
     Ensure migration files created have a descriptive
     name; if default name pattern is found, raise exception
     """
-    args = _parse_args()
+    args = _parse_migration_check_args()
     if not args.migration_path:
-        raise Exception("CLI argument `migration-path` is required "
-                        "but not found")
+        raise Exception('CLI argument `migration-path` is required '
+                        'but not found')
     if args.migrations_to_ignore is None:
         args.migrations_to_ignore = 0
     # QA Check
     migrations_set = set()
     migrations = os.listdir(args.migration_path)
     for migration in migrations:
-        if (re.match(r"^[0-9]{4}_auto_[0-9]{2}", migration) and
+        if (re.match(r'^[0-9]{4}_auto_[0-9]{2}', migration) and
                 int(migration[:4]) > args.migrations_to_ignore):
             migrations_set.add(migration)
     if bool(migrations_set):
         migrations = list(migrations_set)
         file_ = 'file' if len(migrations) < 2 else 'files'
-        raise Exception("Migration %s %s in directory %s must "
-                        "be renamed to something more descriptive."
+        raise Exception('Migration %s %s in directory %s must '
+                        'be renamed to something more descriptive.'
                         % (file_, ', '.join(migrations), args.migration_path))
 
 
-def _commit_check_args():
+def _parse_commit_check_args():
     """
     Parse and return CLI arguments
     """
@@ -64,7 +64,7 @@ def _commit_check_args():
 
 
 def check_commit_message():
-    args = _commit_check_args()
+    args = _parse_commit_check_args()
     long_desc = None
     lines = args.message.split('\n')
     short_desc = lines[0]

--- a/openwisp_utils/qa.py
+++ b/openwisp_utils/qa.py
@@ -10,7 +10,7 @@ import re
 
 def _parse_args():
     """
-    Parse and return CLI arguements
+    Parse and return CLI arguments
     """
     parser = argparse.ArgumentParser(description="Ensures migration files "
                                      "created have a descriptive name. If "
@@ -34,7 +34,7 @@ def check_migration_name():
     """
     args = _parse_args()
     if not args.migration_path:
-        raise Exception("CLI arguement `migration-path` is required "
+        raise Exception("CLI argument `migration-path` is required "
                         "but not found")
     if args.migrations_to_ignore is None:
         args.migrations_to_ignore = 0
@@ -51,3 +51,146 @@ def check_migration_name():
         raise Exception("Migration %s %s in directory %s must "
                         "be renamed to something more descriptive."
                         % (file_, ', '.join(migrations), args.migration_path))
+
+
+def _commit_check_args():
+    """
+    Parse and return CLI arguments
+    """
+    parser = argparse.ArgumentParser(description="Ensures the commit message "
+                                     "matches the OpenWISP commit guidelines.")
+
+    parser.add_argument("--message",
+                        help="Commit message")
+    return parser.parse_args()
+
+
+def check_commit_message():
+    args = _commit_check_args()
+    if not args.message:
+        raise Exception("CLI argument `message` is required "
+                        "but not found")
+    else:
+        short_desc = args.message.split("\n")[0]
+        if len(args.message.split("\n")) > 1:
+            long_desc = args.message.split("\n")[1:]
+    errors = []
+    # Check dot in end of the first line
+    if short_desc[len(short_desc.strip()) - 1].strip() == '.':
+        errors.append("Do not add a final dot at the end of the first line.")
+    # Check prefix
+    prefix = re.match(r'\[(.*?)\]', short_desc)
+    if not prefix:
+        errors.append(
+            "Add prefix in beginning of the commit. "
+            "Example: [module/file/feature]"
+        )
+    else:
+        # Check capital after prefix
+        commit_message_first = short_desc.replace(prefix.group(), '').strip()
+        if not commit_message_first[0].isupper():
+            errors.append("No capital letter after prefix")
+    # Check blank line before first line and second line
+    if 'long_desc' in locals():
+        if len(args.message.split("\n")) > 1:
+            if args.message.split("\n")[1] != '':
+                errors.append("No blank line before first "
+                              "line and second line")
+        # Mentions an issues without closing it
+        message = ' '.join(long_desc)
+        # Check issues in  long desc
+        long_desc_location = re.search(r'\#(\d+)', message)
+        if long_desc_location:
+            # message_check will return array of number issues when success
+            message_check = _check_word(message)
+            # Checked is variable type is array
+            if(not _is_array(message_check)):
+                errors.append(message_check)
+            # Check hastag if mention issues
+            checked = 0
+            for check in message_check:
+                # Checked is one of issues in short messages
+                short_desc_hastag = re.search(
+                    r'\#' +
+                    check.replace("#", ""),
+                    short_desc
+                )
+                if short_desc_hastag:
+                    checked = checked + 1
+            # If not mentioned issues at least 1 issues
+            if checked == 0:
+                errors.append("No mention issues in the short description")
+        # Check issues in short desc
+        short_desc_location = re.search(r'\#(\d+)', short_desc)
+        if short_desc_location:
+            # Get all issues in long description
+            long_desc_issues = _check_word(message)
+            if not _is_array(long_desc_issues):
+                errors.append("No mention issues in the long description")
+            checked = 0
+            # Foreach all issues
+            for issues in long_desc_issues:
+                # Check is issues in short description
+                long_desc_hastag = re.search(
+                    r'\#' +
+                    issues.replace("#", ""),
+                    short_desc)
+                if long_desc_hastag:
+                    checked = checked + 1
+            if checked == 0:
+                errors.append("No mention issues in the long description")
+    # Check is error
+    if len(errors) == 0:
+        body = "All check done, no errors."
+    else:
+        body = "You have errors with commit message: \n"
+        for e in errors:
+            body += "- " + e + "\n"
+    if len(errors) > 0:
+        raise Exception(body)
+    else:
+        print(body)
+
+
+def _is_array(var):
+    return isinstance(var, (list, tuple))
+
+
+def _check_word(message):
+    parts = message.split(' ')
+    return_data = []
+    loc = []
+    i = 0
+    # Search hastag from parts
+    for part in parts:
+        hastag = re.search(r'\#(\d+)', part)
+        if hastag:
+            loc.append(i)
+        i = i + 1
+    # Check for num hastag with allowed words
+    num = 0
+    for location in loc:
+        word = parts[location - 1]
+        return_data.append(parts[location])
+        if(location > 2):
+            word2 = str(parts[location - 2] + " " + parts[location - 1])
+            allowed_words2 = [
+                'related to',
+                'refers to',
+            ]
+            if((word2.lower() in allowed_words2)):
+                num = num + 1
+                continue
+        allowed_words = [
+            'fix',
+            'fixes',
+            'close',
+            'closes',
+            'ref',
+            'rel'
+        ]
+        if (word.lower() in allowed_words):
+            num = num + 1
+    if num != len(loc):
+        return "Mentions an issues without closing it"
+    return return_data

--- a/openwisp_utils/qa.py
+++ b/openwisp_utils/qa.py
@@ -73,6 +73,8 @@ def _parse_commit_check_args():
 
 def check_commit_message():
     args = _parse_commit_check_args()
+    if '#noqa' in args.message.lower():
+        return
     long_desc = None
     lines = args.message.split('\n')
     short_desc = lines[0]

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
     packages=find_packages(exclude=['tests', 'docs']),
     entry_points={
         'console_scripts': [
-            'checkmigrations = openwisp_utils.qa:check_migration_name'
+            'checkmigrations = openwisp_utils.qa:check_migration_name',
+            'checkcommit = openwisp_utils.qa:check_commit_message',
         ],
     },
     include_package_data=True,

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -84,7 +84,12 @@ class TestQa(TestCase):
         ]
         for option in options:
             with patch('argparse._sys.argv', option):
-                check_commit_message()
+                try:
+                    check_commit_message()
+                except Exception as e:
+                    msg = 'Check failed:\n\n{}' \
+                          '\n\nOutput:{}'.format(option[-1], e)
+                    self.fail(msg)
 
     def test_qa_call_check_commit_message_failure(self):
         options = [
@@ -112,26 +117,26 @@ class TestQa(TestCase):
             [
                 'commitcheck',
                 '--message',
-                "[qa] Updated more file and fix problem #20"
-                "\n\nAdded more files #20"
+                "[qa] Fixed problem #20"
+                "\n\nFixed problem X #20"
             ],
             [
                 'commitcheck',
                 '--message',
                 "[qa] Finished task #2\n\n"
+                "Resolves problem described in #2"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Fixed problem\n\n"
                 "Failure #2\nRelated to #1"
             ],
             [
                 'commitcheck',
                 '--message',
-                "[qa] Finished task\n\n"
-                "Failure #2\nRelated to #1"
-            ],
-            [
-                'commitcheck',
-                '--message',
-                "[qa] Updated more file and fix problem\n\n"
-                "Added more files Fixes #20"
+                "[qa] Updated file and fixed problem\n\n"
+                "Added more files. Fixes #20"
             ],
             [
                 'commitcheck',

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 # Mock is a standard library from python3.3-pre onwards
 # from unittest.mock import patch
 from mock import patch
-from openwisp_utils.qa import check_migration_name
+from openwisp_utils.qa import check_commit_message, check_migration_name
 
 MIGRATIONS_DIR = path.join(path.dirname(path.dirname(path.abspath(__file__))), 'migrations')
 
@@ -39,6 +39,123 @@ class TestQa(TestCase):
             with patch('argparse._sys.argv', option):
                 try:
                     check_migration_name()
+                except (SystemExit, Exception):
+                    pass
+                else:
+                    self.fail('SystemExit or Exception not raised')
+
+    def test_qa_call_check_commit_message_pass(self):
+        options = [
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Minor clean up operations"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Updated more file and fix problem #20\n\n"
+                "Added more files Fixes #20"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Improved Y #2\n\n"
+                "Related to #2"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Finished task #2\n\n"
+                "Closes #2\nRelated to #1"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Finished task #2\n\n"
+                "Related to #2\nCloses #1"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Finished task #2\n\n"
+                "Related to #2\nRelated to #1"
+            ]
+        ]
+        for option in options:
+            with patch('argparse._sys.argv', option):
+                check_commit_message()
+
+    def test_qa_call_check_commit_message_failure(self):
+        options = [
+            ['commitcheck'],
+            [
+                'commitcheck',
+                '--message',
+                'Hello World',
+            ],
+            [
+                'commitcheck',
+                '--message',
+                '[qa] hello World',
+            ],
+            [
+                'commitcheck',
+                '--message',
+                '[qa] Hello World.',
+            ],
+            [
+                'commitcheck',
+                '--message',
+                '[qa] Hello World.\nFixes #20',
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Updated more file and fix problem #20"
+                "\n\nAdded more files #20"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Finished task #2\n\n"
+                "Failure #2\nRelated to #1"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Finished task\n\n"
+                "Failure #2\nRelated to #1"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Updated more file and fix problem\n\n"
+                "Added more files Fixes #20"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Improved Y\n\n"
+                "Related to #2"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Improved Y #2\n\n"
+                "Updated files"
+            ],
+            [
+                'commitcheck',
+                '--message',
+                "[qa] Improved Y #20\n\n"
+                "Related to #32 Fixes #30 Fix #40"
+            ],
+        ]
+        for option in options:
+            with patch('argparse._sys.argv', option):
+                try:
+                    check_commit_message()
                 except (SystemExit, Exception):
                     pass
                 else:

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -20,8 +20,10 @@ class TestQa(TestCase):
 
     def test_qa_call_check_migration_name_pass(self):
         options = [
-            'checkmigrations', '--migrations-to-ignore', '2',
-            '--migration-path', MIGRATIONS_DIR
+            'checkmigrations',
+            '--migrations-to-ignore', '2',
+            '--migration-path', MIGRATIONS_DIR,
+            '--quiet'
         ]
         with patch('argparse._sys.argv', options):
             check_migration_name()
@@ -29,10 +31,16 @@ class TestQa(TestCase):
     def test_qa_call_check_migration_name_failure(self):
         options = [
             [
-                'checkmigrations', '--migrations-to-ignore', '1',
-                '--migration-path', MIGRATIONS_DIR
+                'checkmigrations',
+                '--migrations-to-ignore', '1',
+                '--migration-path', MIGRATIONS_DIR,
+                '--quiet'
             ],
-            ['checkmigrations', '--migration-path', MIGRATIONS_DIR],
+            [
+                'checkmigrations',
+                '--migration-path', MIGRATIONS_DIR,
+                '--quiet'
+            ],
             ['checkmigrations']
         ]
         for option in options:
@@ -48,36 +56,36 @@ class TestQa(TestCase):
         options = [
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Minor clean up operations"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Updated more file and fix problem #20\n\n"
                 "Added more files Fixes #20"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Improved Y #2\n\n"
                 "Related to #2"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Finished task #2\n\n"
                 "Closes #2\nRelated to #1"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Finished task #2\n\n"
                 "Related to #2\nCloses #1"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Finished task #2\n\n"
                 "Related to #2\nRelated to #1"
             ]
@@ -96,63 +104,63 @@ class TestQa(TestCase):
             ['commitcheck'],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 'Hello World',
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 '[qa] hello World',
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 '[qa] Hello World.',
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 '[qa] Hello World.\nFixes #20',
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Fixed problem #20"
                 "\n\nFixed problem X #20"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Finished task #2\n\n"
                 "Resolves problem described in #2"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Fixed problem\n\n"
                 "Failure #2\nRelated to #1"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Updated file and fixed problem\n\n"
                 "Added more files. Fixes #20"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Improved Y\n\n"
                 "Related to #2"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Improved Y #2\n\n"
                 "Updated files"
             ],
             [
                 'commitcheck',
-                '--message',
+                '--quiet', '--message',
                 "[qa] Improved Y #20\n\n"
                 "Related to #32 Fixes #30 Fix #40"
             ],

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -26,7 +26,10 @@ class TestQa(TestCase):
             '--quiet'
         ]
         with patch('argparse._sys.argv', options):
-            check_migration_name()
+            try:
+                check_migration_name()
+            except (SystemExit, Exception) as e:
+                self.fail(e)
 
     def test_qa_call_check_migration_name_failure(self):
         options = [
@@ -88,13 +91,20 @@ class TestQa(TestCase):
                 '--quiet', '--message',
                 "[qa] Finished task #2\n\n"
                 "Related to #2\nRelated to #1"
+            ],
+            # noqa
+            [
+                'commitcheck',
+                '--quiet', '--message',
+                "[qa] Improved Y #20\n\n"
+                "Simulation of a special unplanned case\n\n#noqa"
             ]
         ]
         for option in options:
             with patch('argparse._sys.argv', option):
                 try:
                     check_commit_message()
-                except Exception as e:
+                except (SystemExit, Exception) as e:
                     msg = 'Check failed:\n\n{}' \
                           '\n\nOutput:{}'.format(option[-1], e)
                     self.fail(msg)
@@ -163,7 +173,7 @@ class TestQa(TestCase):
                 '--quiet', '--message',
                 "[qa] Improved Y #20\n\n"
                 "Related to #32 Fixes #30 Fix #40"
-            ],
+            ]
         ]
         for option in options:
             with patch('argparse._sys.argv', option):


### PR DESCRIPTION
Round 2 of #25, I hope the build won't get stuck this time.

@ppabcd see the improvements to your code, especially regarding readability

@atb00ker I found out a few things that needed improvement in the migration check as well, these kind of checks are designed to be used as linux commands so they should not raise exceptions in case of failure but simply print a message and exit with an exit code higher than zero.

I've added some basic docs in the readme and last but not least I've added a way to skip the commit message check (using the `#noqa` keyword in the commit message) in case we encounter some legit case which we didn't plan here and we don't want to block the build, we may remove this option in the future once we are confident all cases are covered.

Related to #20 and #23.