### PR TITLE
[requirements] Update dependencies & drop python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,14 @@ language: python
 cache: pip
 
 python:
-  - "3.5"
-  - "2.7"
+  - "3.7"
 
 env:
   - DJANGO="django>=1.11,<1.12"
   - DJANGO="django>=2.0,<2.1"
   - DJANGO="django>=2.1,<2.2"
   - DJANGO="django>=2.2,<3.0"
-
-matrix:
-  exclude:
-    - python: "2.7"
-      env: DJANGO="django>=2.0,<2.1"
-    - python: "2.7"
-      env: DJANGO="django>=2.1,<2.2"
-    - python: "2.7"
-      env: DJANGO="django>=2.2,<3.0"
+  - DJANGO="django>=3.0,<3.1"
 
 branches:
   only:

--- a/openwisp_utils/admin.py
+++ b/openwisp_utils/admin.py
@@ -8,7 +8,7 @@ class TimeReadonlyAdminMixin(object):
     """
     def __init__(self, *args, **kwargs):
         self.readonly_fields += ('created', 'modified',)
-        super(TimeReadonlyAdminMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class ReadOnlyAdmin(ModelAdmin):
@@ -16,11 +16,11 @@ class ReadOnlyAdmin(ModelAdmin):
     Disables all editing capabilities
     """
     def __init__(self, *args, **kwargs):
-        super(ReadOnlyAdmin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.readonly_fields = [f.name for f in self.model._meta.fields]
 
     def get_actions(self, request):
-        actions = super(ReadOnlyAdmin, self).get_actions(request)
+        actions = super().get_actions(request)
         if 'delete_selected' in actions:  # pragma: no cover
             del actions['delete_selected']
         return actions
@@ -44,9 +44,7 @@ class ReadOnlyAdmin(ModelAdmin):
         extra_context = extra_context or {}
         extra_context['show_save_and_continue'] = False
         extra_context['show_save'] = False
-        return super(ReadOnlyAdmin, self).change_view(request,
-                                                      object_id,
-                                                      extra_context=extra_context)
+        return super().change_view(request, object_id, extra_context=extra_context)
 
 
 class AlwaysHasChangedMixin(object):
@@ -59,4 +57,4 @@ class AlwaysHasChangedMixin(object):
         """
         if self.instance._state.adding:
             return True
-        return super(AlwaysHasChangedMixin, self).has_changed()
+        return super().has_changed()

--- a/openwisp_utils/staticfiles.py
+++ b/openwisp_utils/staticfiles.py
@@ -25,4 +25,3 @@ class DependencyFinder(FileSystemFinder):
             filesystem_storage = FileSystemStorage(location=root)
             filesystem_storage.prefix = prefix
             self.storages[root] = filesystem_storage
-        super(FileSystemFinder, self).__init__(*args, **kwargs)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,6 +2,3 @@ coveralls
 # For testing Dependency loaders
 django_netjsonconfig
 djangorestframework
-# TODO: To be removed when we drop python 2.7 support
-# Mock is a standard library from python3.3-pre onwards
-mock>=2.0.0,<2.1.0

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup(
     scripts=['openwisp-utils-qa-checks'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=['django-model-utils>=3.1.2,<3.3.0'],
+    install_requires=['django-model-utils>=3.1.2,<4.1.0'],
     extras_require={
-        'qa': ['flake8<=3.6.0', 'isort<=4.3.4'],
+        'qa': ['flake8<=3.7.9', 'isort<=4.3.31'],
     },
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -53,7 +53,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Framework :: Django',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3',
     ]
 )

--- a/tests/test_project/tests/test_admin.py
+++ b/tests/test_project/tests/test_admin.py
@@ -2,8 +2,8 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
-from . import CreateMixin
 from ..models import Operator, Project, RadiusAccounting
+from . import CreateMixin
 
 User = get_user_model()
 

--- a/tests/test_project/tests/test_api.py
+++ b/tests/test_project/tests/test_api.py
@@ -2,8 +2,8 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from test_project.serializers import ShelfSerializer
 
-from . import CreateMixin
 from ..models import Shelf
+from . import CreateMixin
 
 
 class TestApi(CreateMixin, TestCase):

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -1,17 +1,9 @@
 import os
 from os import path
+from unittest.mock import patch
 
 from django.test import TestCase
 from openwisp_utils.qa import check_commit_message, check_migration_name
-
-# TODO: To be removed when we drop python 2.7 support
-# Mock is a standard library from python3.3-pre onwards
-# from unittest.mock import patch
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 
 MIGRATIONS_DIR = path.join(path.dirname(path.dirname(path.abspath(__file__))), 'migrations')
 


### PR DESCRIPTION
Dropped python2 support and updated requirements.
Fixes https://github.com/openwisp/openwisp-utils/issues/43