### PR TITLE
[ci] Implicitly get coverage version from coveralls

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-coverage
 coveralls
 # For testing Dependency loaders
 django_netjsonconfig


### PR DESCRIPTION
The coveralls package already has a dependency on coverage
and sets the boundary according to its support for the coverage library.
We should not duplicate this information.