### PR TITLE
[enhancement] Make openwisp-utils-qa-checks fail on unknown argument

### DIFF
--- a/openwisp-utils-qa-checks
+++ b/openwisp-utils-qa-checks
@@ -166,7 +166,7 @@ while [ "$1" != "" ]; do
     printf "Unknown argument: %s\n" "$1"
     printf "\n"
     show_help
-    exit
+    exit 1
     ;;
   esac
   shift


### PR DESCRIPTION
When unknown argument is passed to `openwisp-utils-qa-checks` it exits with 0, as if everything is ok. This PR fixes it.