### PR TITLE
[ci] Newline is not interpreted in openwisp-utils-qa-checks #72

### DIFF
--- a/openwisp-utils-qa-checks
+++ b/openwisp-utils-qa-checks
@@ -98,7 +98,7 @@ runcheckcommit() {
 
 runcheckpendingmigrations() {
   if [ ! -f "./tests/manage.py" ]; then
-    echo "File manage.py not found\nSkipping Make Migration Check"
+    echo "File manage.py not found, skipping Make Migration Check."
   else
     OUTPUT=$(python tests/manage.py makemigrations --dry-run $MODULE)
     echo $OUTPUT


### PR DESCRIPTION
Changed echo to printf in pending migrations check