### PR TITLE
[admin-theme] Adding custom CSS and JS #79

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,44 @@ template ``context_processors`` in ``settings.py`` as shown below.
         },
     ]
 
+Using Custom CSS and JS for Admin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add ``openwisp_utils.admin_theme.context_processor.admin_theme_settings`` to
+template ``context_processors`` in ``settings.py`` as shown below.
+This will allow to set ``OPENWISP_ADMIN_THEME_CSS`` and ``OPENWISP_ADMIN_THEME_JS`` settings
+to provide CSS and JS files to customise admin theme.
+
+.. code-block:: python
+
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'OPTIONS': {
+                'loaders': [
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                    'openwisp_utils.loaders.DependencyLoader',
+                ],
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                    'openwisp_utils.admin_theme.context_processor.menu_items',
+                    'openwisp_utils.admin_theme.context_processor.admin_theme_settings'
+                ],
+            },
+        },
+    ]
+
+.. note::
+    You will have to manually deploy these static files.
+     One way to do this is by adding the directory containing these static files to the ``STATICFILES_DIR`` setting in ``settings.py``.
+     You can learn more at `Django Documentation <https://docs.djangoproject.com/en/3.0/ref/settings/#std:setting-STATICFILES_DIRS>`_.
+
+
 Settings
 ^^^^^^^^
 
@@ -255,6 +293,38 @@ Example usage:
         }
     ]
 
+``OPENWISP_ADMIN_THEME_CSS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**default**: ``[]``
+
+Allows passing a list containing strings of URLs of custom CSS files.
+ Adding this setting does not override the default theme,
+ rather you will have to override, CSS selectors in your CSS.
+
+Example usage:
+
+.. code-block:: python
+
+    OPENWISP_ADMIN_THEME_CSS = [
+    	'http://127.0.0.1:8000/static/custom-admin-theme.css',
+	]
+	
+``OPENWISP_ADMIN_THEME_JS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**default**: ``[]``
+
+Allows to pass a list contaning strings of URLs of custom JS files.
+
+Example usage:
+
+.. code-block:: python
+
+    OPENWISP_ADMIN_THEME_JS = [
+        'http://127.0.0.1:8000/static/custom-admin-theme.js',
+	]
+    
 Quality Assurance checks
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/openwisp_utils/admin_theme/apps.py
+++ b/openwisp_utils/admin_theme/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
 
 from . import settings as app_settings
+from .checks import admin_theme_settings_checks
 
 
 class OpenWispAdminThemeConfig(AppConfig):
@@ -8,6 +9,7 @@ class OpenWispAdminThemeConfig(AppConfig):
     name = 'openwisp_utils.admin_theme'
 
     def ready(self):
+        admin_theme_settings_checks(self)
         # monkey patch django.contrib.admin.apps.AdminConfig.default_site
         # in order to supply our customized admin site class
         # this is necessary in order to avoid having to modify

--- a/openwisp_utils/admin_theme/checks.py
+++ b/openwisp_utils/admin_theme/checks.py
@@ -1,0 +1,27 @@
+from django.core.checks import Error, register
+
+from . import settings as app_settings
+
+
+@register()
+def admin_theme_settings_checks(app_configs, **kwargs):
+    errors = []
+    is_list_of_str = all(isinstance(item, str) for item in app_settings.OPENWISP_ADMIN_THEME_CSS)
+    if not isinstance(app_settings.OPENWISP_ADMIN_THEME_CSS, list) or not is_list_of_str:
+        errors.append(
+            Error(
+                msg='Improperly Configured',
+                hint='OPENWISP_ADMIN_THEME_CSS should be a list of strings.',
+                obj='OPENWISP_ADMIN_THEME_CSS',
+            )
+        )
+    is_list_of_str = all(isinstance(item, str) for item in app_settings.OPENWISP_ADMIN_THEME_JS)
+    if not isinstance(app_settings.OPENWISP_ADMIN_THEME_JS, list) or not is_list_of_str:
+        errors.append(
+            Error(
+                msg='Improperly Configured',
+                hint='OPENWISP_ADMIN_THEME_JS should be a list of strings.',
+                obj='OPENWISP_ADMIN_THEME_JS',
+            )
+        )
+    return errors

--- a/openwisp_utils/admin_theme/context_processor.py
+++ b/openwisp_utils/admin_theme/context_processor.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from django.contrib.admin import site
 from django.urls import reverse
 
+from . import settings as app_settings
+
 
 def menu_items(request):
     menu = build_menu(request)
@@ -37,3 +39,10 @@ def build_menu(request=None):
                 'class': model.lower()
             })
     return menu
+
+
+def admin_theme_settings(request):
+    return {
+        'OPENWISP_ADMIN_THEME_CSS': app_settings.OPENWISP_ADMIN_THEME_CSS,
+        'OPENWISP_ADMIN_THEME_JS': app_settings.OPENWISP_ADMIN_THEME_JS,
+    }

--- a/openwisp_utils/admin_theme/settings.py
+++ b/openwisp_utils/admin_theme/settings.py
@@ -3,3 +3,6 @@ from django.conf import settings
 ADMIN_SITE_CLASS = getattr(settings,
                            'OPENWISP_ADMIN_SITE_CLASS',
                            'openwisp_utils.admin_theme.admin.OpenwispAdminSite')
+
+OPENWISP_ADMIN_THEME_CSS = getattr(settings, 'OPENWISP_ADMIN_THEME_CSS', [])
+OPENWISP_ADMIN_THEME_JS = getattr(settings, 'OPENWISP_ADMIN_THEME_JS', [])

--- a/openwisp_utils/admin_theme/templates/admin/base_site.html
+++ b/openwisp_utils/admin_theme/templates/admin/base_site.html
@@ -6,6 +6,11 @@
 {% block extrastyle %}
 {{ block.super }}
 <link rel="stylesheet" type="text/css" href="{% static "admin/css/openwisp.css" %}" />
+{% if OPENWISP_ADMIN_THEME_CSS %}
+    {% for css in OPENWISP_ADMIN_THEME_CSS %}
+        <link rel="stylesheet" type="text/css" href="{{ css }}" />
+    {% endfor %}
+{% endif %}
 <link rel="icon" type="image/x-icon" href="{% static "ui/openwisp/images/favicon.png" %}" />
 {% endblock %}
 
@@ -55,6 +60,11 @@
     loaded before jQuery is loaded
 {% endcomment %}
 {% if has_permission %}
-<script src="{% static "admin/js/menu.js" %}"></script>
+    <script src="{% static "admin/js/menu.js" %}"></script>
+{% endif %}
+{% if OPENWISP_ADMIN_THEME_JS %}
+    {% for js in OPENWISP_ADMIN_THEME_JS %}
+        <script type="text/javascript" src="{{ js }}"></script>
+    {% endfor %}
 {% endif %}
 {% endblock %}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -64,7 +64,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'openwisp_utils.admin_theme.context_processor.menu_items'
+                'openwisp_utils.admin_theme.context_processor.menu_items',
+                'openwisp_utils.admin_theme.context_processor.admin_theme_settings',
             ],
         },
     },
@@ -92,3 +93,6 @@ try:
     from local_settings import *
 except ImportError:
     pass
+
+STATICFILES_DIRS = ( os.path.join(BASE_DIR,'test_project'),)
+

--- a/tests/test_project/static/custom-admin-theme.css
+++ b/tests/test_project/static/custom-admin-theme.css
@@ -1,0 +1,1 @@
+/* Dummy file for testing of Custom Admin CSS */


### PR DESCRIPTION
Added feature to pass custom CSS and JS for admin theme by providing values for  `OPENWISP_ADMIN_THEME_CSS` and `OPENWISP_ADMIN_JS` settings.
Added documentation and tests for the above feature.
P.S: Should be merged after #80 :smile: 
Closes #79