### PR TITLE
[black] Add black support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Install from pypi:
 .. code-block:: shell
 
     pip install openwisp-utils
-    # install optional dependencies for tests (flake8 and isort)
+    # install optional dependencies for tests (flake8, black and isort)
     pip install openwisp-utils[qa]
 
 Install development version
@@ -327,7 +327,7 @@ This package contains some utilities that are used in the automated builds
 of different OpenWISP modules.
 
 ``catch_signal``
-~~~~~~~~~~~~~~~~ 
+~~~~~~~~~~~~~~~~
 
 This method can be used to mock a signal call inorder to easily verify
 that the signal has been called.
@@ -350,6 +350,11 @@ Quality Assurance checks
 This package contains some common QA checks that are used in the
 automated builds of different OpenWISP modules.
 
+``openwisp-qa-format``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Shell script to automatically format Python code. It runs ``isort`` and ``black``.
+
 ``openwisp-utils-qa-checks``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -361,6 +366,7 @@ Shell script to run the following quality assurance checks:
 * `checkpendingmigrations <#checkpendingmigrations>`_
 * ``flake8`` - Python code linter
 * ``isort`` - Sorts python imports alphabetically, and seperated into sections
+* ``black`` - Formats python code using a common standard
 
 If a check requires a flag, it can be passed forward in the same way.
 

--- a/openwisp-qa-format
+++ b/openwisp-qa-format
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+isort -y . --recursive
+black -S .

--- a/openwisp-utils-qa-checks
+++ b/openwisp-utils-qa-checks
@@ -9,6 +9,7 @@ show_help() {
   printf "            [--skip-checkendline]\n"
   printf "            [--skip-flake8]\n"
   printf "            [--skip-isort]\n"
+  printf "            [--skip-black]\n"
   printf "\n"
   printf "Runs all checks for quality assurance. Unneeded checks may be skipped by passing --skip-<check-name> argument.\n"
   printf "\n"
@@ -32,6 +33,8 @@ show_help() {
   printf "  --skip-flake8\t\t\t: Skip flake8 check\n"
   printf "Isort check options:\n"
   printf "  --skip-isort\t\t\t: Skip isort check\n"
+  printf "Black check options:\n"
+  printf "  --skip-black\t\t\t: Skip black check\n"
 }
 
 echoerr() { echo "$@" 1>&2; }
@@ -80,7 +83,13 @@ runflake8() {
 runisort() {
   isort --check-only --recursive --diff \
     && echo "SUCCESS: Isort check successful!" \
-    || { echoerr "ERROR: Isort check failed!"; FAILURE=1; }
+    || { echoerr "ERROR: Isort check failed! Hint: did you forget running openwisp-qa-format?"; FAILURE=1; }
+}
+
+runblack() {
+  black -S --check --diff . \
+    && echo "SUCCESS: Black check successful!" \
+    || { echoerr "ERROR: Black check failed! Hint: did you forget running openwisp-qa-format?"; FAILURE=1; }
 }
 
 runcheckcommit() {
@@ -114,6 +123,7 @@ SKIP_CHECKMIGRATIONS=false
 SKIP_MAKEMIGRATIONS=false
 SKIP_FLAKE8=false
 SKIP_ISORT=false
+SKIP_BLACK=false
 SKIP_CHECKCOMMIT=false
 MIGRATION_PATH=""
 MIGRATIONS_TO_IGNORE="0"
@@ -142,6 +152,9 @@ while [ "$1" != "" ]; do
     ;;
   --skip-isort)
     SKIP_ISORT=true
+    ;;
+  --skip-black)
+    SKIP_BLACK=true
     ;;
   --skip-checkcommit)
     SKIP_CHECKCOMMIT=true
@@ -190,6 +203,10 @@ fi
 
 if ! $SKIP_ISORT; then
   runisort
+fi
+
+if ! $SKIP_BLACK; then
+  runblack
 fi
 
 if ! $SKIP_CHECKCOMMIT; then

--- a/openwisp_utils/admin.py
+++ b/openwisp_utils/admin.py
@@ -10,7 +10,10 @@ class TimeReadonlyAdminMixin(object):
     """
 
     def __init__(self, *args, **kwargs):
-        self.readonly_fields += ('created', 'modified',)
+        self.readonly_fields += (
+            'created',
+            'modified',
+        )
         super().__init__(*args, **kwargs)
 
 
@@ -106,6 +109,7 @@ class ReceiveUrlAdmin(ModelAdmin):
     a view_name concatenated with the obj id and/or
     with the key of the obj
     """
+
     receive_url_querystring_arg = 'key'
     receive_url_object_arg = 'pk'
     receive_url_name = None
@@ -129,24 +133,22 @@ class ReceiveUrlAdmin(ModelAdmin):
         reverse_kwargs = {}
         if self.receive_url_object_arg:
             reverse_kwargs = {
-                self.receive_url_object_arg:
-                getattr(obj, self.receive_url_object_arg)
+                self.receive_url_object_arg: getattr(obj, self.receive_url_object_arg)
             }
-        receive_path = reverse(self.receive_url_name,
-                               urlconf=self.receive_url_urlconf,
-                               kwargs=reverse_kwargs)
+        receive_path = reverse(
+            self.receive_url_name,
+            urlconf=self.receive_url_urlconf,
+            kwargs=reverse_kwargs,
+        )
         baseurl = self.receive_url_baseurl
         if not baseurl:
-            baseurl = '{0}://{1}'.format(
-                self.request.scheme,
-                self.request.get_host(),
-            )
+            baseurl = '{0}://{1}'.format(self.request.scheme, self.request.get_host(),)
         if self.receive_url_querystring_arg:
             url = '{0}{1}?{2}={3}'.format(
                 baseurl,
                 receive_path,
                 self.receive_url_querystring_arg,
-                getattr(obj, self.receive_url_querystring_arg)
+                getattr(obj, self.receive_url_querystring_arg),
             )
         return url
 

--- a/openwisp_utils/admin_theme/admin.py
+++ b/openwisp_utils/admin_theme/admin.py
@@ -9,18 +9,12 @@ logger = logging.getLogger(__name__)
 
 class OpenwispAdminSite(admin.AdminSite):
     # <title>
-    site_title = getattr(settings,
-                         'OPENWISP_ADMIN_SITE_TITLE',
-                         'OpenWISP Admin')
+    site_title = getattr(settings, 'OPENWISP_ADMIN_SITE_TITLE', 'OpenWISP Admin')
     # h1 text
-    site_header = getattr(settings,
-                          'OPENWISP_ADMIN_SITE_HEADER',
-                          'OpenWISP')
+    site_header = getattr(settings, 'OPENWISP_ADMIN_SITE_HEADER', 'OpenWISP')
     # text at the top of the admin index page
     index_title = ugettext_lazy(
-        getattr(settings,
-                'OPENWISP_ADMIN_INDEX_TITLE',
-                'Network administration')
+        getattr(settings, 'OPENWISP_ADMIN_INDEX_TITLE', 'Network administration')
     )
 
 

--- a/openwisp_utils/admin_theme/apps.py
+++ b/openwisp_utils/admin_theme/apps.py
@@ -15,4 +15,5 @@ class OpenWispAdminThemeConfig(AppConfig):
         # this is necessary in order to avoid having to modify
         # many other openwisp modules and repos
         from django.contrib import admin
+
         admin.apps.AdminConfig.default_site = app_settings.ADMIN_SITE_CLASS

--- a/openwisp_utils/admin_theme/checks.py
+++ b/openwisp_utils/admin_theme/checks.py
@@ -19,12 +19,14 @@ def admin_theme_settings_checks(app_configs, **kwargs):
             Error(
                 msg='Invalid item: {}'.format(item),
                 hint='OPENWISP_ADMIN_THEME_LINKS should be a list of dictionaries, '
-                     'each dictionary must contain the following keys: rel, type and href.',
+                'each dictionary must contain the following keys: rel, type and href.',
                 obj='OPENWISP_ADMIN_THEME_LINKS',
             )
         )
 
-    is_list_of_str = all(isinstance(item, str) for item in app_settings.OPENWISP_ADMIN_THEME_JS)
+    is_list_of_str = all(
+        isinstance(item, str) for item in app_settings.OPENWISP_ADMIN_THEME_JS
+    )
     if not isinstance(app_settings.OPENWISP_ADMIN_THEME_JS, list) or not is_list_of_str:
         errors.append(
             Error(

--- a/openwisp_utils/admin_theme/context_processor.py
+++ b/openwisp_utils/admin_theme/context_processor.py
@@ -11,10 +11,8 @@ def menu_items(request):
     return {
         'openwisp_menu_items': menu,
         'show_userlinks_block': getattr(
-            settings,
-            'OPENWISP_ADMIN_SHOW_USERLINKS_BLOCK',
-            False
-        )
+            settings, 'OPENWISP_ADMIN_SHOW_USERLINKS_BLOCK', False
+        ),
     }
 
 
@@ -28,16 +26,11 @@ def build_menu(request=None):
     for item in items:
         app_label, model = item['model'].split('.')
         model_class = registry.apps.get_model(app_label, model)
-        url = reverse('admin:{}_{}_changelist'.format(app_label,
-                                                      model.lower()))
+        url = reverse('admin:{}_{}_changelist'.format(app_label, model.lower()))
         label = item.get('label', model_class._meta.verbose_name_plural)
         model_admin = site._registry[model_class]
         if not request or model_admin.has_module_permission(request):
-            menu.append({
-                'url': url,
-                'label': label,
-                'class': model.lower()
-            })
+            menu.append({'url': url, 'label': label, 'class': model.lower()})
     return menu
 
 

--- a/openwisp_utils/admin_theme/settings.py
+++ b/openwisp_utils/admin_theme/settings.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 
-ADMIN_SITE_CLASS = getattr(settings,
-                           'OPENWISP_ADMIN_SITE_CLASS',
-                           'openwisp_utils.admin_theme.admin.OpenwispAdminSite')
+ADMIN_SITE_CLASS = getattr(
+    settings,
+    'OPENWISP_ADMIN_SITE_CLASS',
+    'openwisp_utils.admin_theme.admin.OpenwispAdminSite',
+)
 
 OPENWISP_ADMIN_THEME_LINKS = getattr(settings, 'OPENWISP_ADMIN_THEME_LINKS', [])
 OPENWISP_ADMIN_THEME_JS = getattr(settings, 'OPENWISP_ADMIN_THEME_JS', [])

--- a/openwisp_utils/api/serializers.py
+++ b/openwisp_utils/api/serializers.py
@@ -3,8 +3,10 @@ from django.core.exceptions import ImproperlyConfigured
 try:
     from rest_framework import serializers
 except ImportError:  # pragma: nocover
-    raise ImproperlyConfigured('Django REST Framework is required to use '
-                               'this feature but it is not installed')
+    raise ImproperlyConfigured(
+        'Django REST Framework is required to use '
+        'this feature but it is not installed'
+    )
 
 
 class ValidatedModelSerializer(serializers.ModelSerializer):

--- a/openwisp_utils/base.py
+++ b/openwisp_utils/base.py
@@ -19,6 +19,7 @@ class TimeStampedEditableModel(UUIDModel):
     An abstract base class model that provides self-updating
     ``created`` and ``modified`` fields.
     """
+
     created = AutoCreatedField(_('created'), editable=True)
     modified = AutoLastModifiedField(_('modified'), editable=True)
 
@@ -30,18 +31,24 @@ class KeyField(models.CharField):
     default_callable = get_random_key
     default_validators = [key_validator]
 
-    def __init__(self,
-                 max_length: int = 64,
-                 unique: bool = False,
-                 db_index: bool = False,
-                 help_text: str = None,
-                 default: [str, callable, None] = default_callable,
-                 validators: list = default_validators,
-                 *args, **kwargs):
-        super().__init__(max_length=max_length,
-                         unique=unique,
-                         db_index=db_index,
-                         help_text=help_text,
-                         default=default,
-                         validators=validators,
-                         *args, **kwargs)
+    def __init__(
+        self,
+        max_length: int = 64,
+        unique: bool = False,
+        db_index: bool = False,
+        help_text: str = None,
+        default: [str, callable, None] = default_callable,
+        validators: list = default_validators,
+        *args,
+        **kwargs
+    ):
+        super().__init__(
+            max_length=max_length,
+            unique=unique,
+            db_index=db_index,
+            help_text=help_text,
+            default=default,
+            validators=validators,
+            *args,
+            **kwargs
+        )

--- a/openwisp_utils/loaders.py
+++ b/openwisp_utils/loaders.py
@@ -10,6 +10,7 @@ class DependencyLoader(FilesystemLoader):
     A template loader that looks in templates dir of
     django-apps listed in dependencies. Default values is []
     """
+
     dependencies = EXTENDED_APPS
 
     def get_dirs(self):

--- a/openwisp_utils/qa.py
+++ b/openwisp_utils/qa.py
@@ -11,22 +11,24 @@ def _parse_migration_check_args():
     """
     Parse and return CLI arguments
     """
-    parser = argparse.ArgumentParser(description='Ensures migration files '
-                                     'created have a descriptive name. If '
-                                     'default name pattern is found, '
-                                     'raise exception!')
-    parser.add_argument('--migration-path',
-                        required=True,
-                        help='Path to `migrations/` folder')
-    parser.add_argument('--migrations-to-ignore',
-                        type=int,
-                        help='Number of migrations after which checking of '
-                        'migration file names should begin, say, if checking '
-                        'needs to start after `0003_auto_20150410_3242.py` '
-                        'value should be `3`')
-    parser.add_argument('--quiet',
-                        action='store_true',
-                        help='Suppress output')
+    parser = argparse.ArgumentParser(
+        description='Ensures migration files '
+        'created have a descriptive name. If '
+        'default name pattern is found, '
+        'raise exception!'
+    )
+    parser.add_argument(
+        '--migration-path', required=True, help='Path to `migrations/` folder'
+    )
+    parser.add_argument(
+        '--migrations-to-ignore',
+        type=int,
+        help='Number of migrations after which checking of '
+        'migration file names should begin, say, if checking '
+        'needs to start after `0003_auto_20150410_3242.py` '
+        'value should be `3`',
+    )
+    parser.add_argument('--quiet', action='store_true', help='Suppress output')
     return parser.parse_args()
 
 
@@ -42,15 +44,19 @@ def check_migration_name():
     migrations_set = set()
     migrations = os.listdir(args.migration_path)
     for migration in migrations:
-        if (re.match(r'^[0-9]{4}_auto_[0-9]{2}', migration) and
-                int(migration[:4]) > args.migrations_to_ignore):
+        if (
+            re.match(r'^[0-9]{4}_auto_[0-9]{2}', migration)
+            and int(migration[:4]) > args.migrations_to_ignore
+        ):
             migrations_set.add(migration)
     if bool(migrations_set):
         migrations = list(migrations_set)
         file_ = 'file' if len(migrations) < 2 else 'files'
-        message = 'Migration %s %s in directory %s must ' \
-                  'be renamed to something more descriptive.' \
-                  % (file_, ', '.join(migrations), args.migration_path)
+        message = (
+            'Migration %s %s in directory %s must '
+            'be renamed to something more descriptive.'
+            % (file_, ', '.join(migrations), args.migration_path)
+        )
         if not args.quiet:
             print(message)
         sys.exit(1)
@@ -60,14 +66,12 @@ def _parse_commit_check_args():
     """
     Parse and return CLI arguments
     """
-    parser = argparse.ArgumentParser(description='Ensures the commit message '
-                                     'follows the OpenWISP commit guidelines.')
-    parser.add_argument('--message',
-                        help='Commit message',
-                        required=True)
-    parser.add_argument('--quiet',
-                        action='store_true',
-                        help='Suppress output')
+    parser = argparse.ArgumentParser(
+        description='Ensures the commit message '
+        'follows the OpenWISP commit guidelines.'
+    )
+    parser.add_argument('--message', help='Commit message', required=True)
+    parser.add_argument('--quiet', action='store_true', help='Suppress output')
     return parser.parse_args()
 
 
@@ -93,8 +97,9 @@ def check_commit_message():
     errors = []
     # no final dot
     if short_desc and short_desc[-1] == '.':
-        errors.append('please do not add a final dot at the '
-                      'end of commit short description')
+        errors.append(
+            'please do not add a final dot at the ' 'end of commit short description'
+        )
     # ensure prefix is present
     prefix = re.match(r'\[(.*?)\]', short_desc)
     if not prefix:
@@ -157,12 +162,16 @@ def check_commit_message():
                 )
     # fail in case of error
     if len(errors):
-        body = 'Your commit message does not follow our ' \
-               'commit message style guidelines:\n\n'
+        body = (
+            'Your commit message does not follow our '
+            'commit message style guidelines:\n\n'
+        )
         for error in errors:
             body += '- {}\n'.format(error)
-        url = 'http://openwisp.io/docs/developer/contributing.html' \
-              '#commit-message-style-guidelines'
+        url = (
+            'http://openwisp.io/docs/developer/contributing.html'
+            '#commit-message-style-guidelines'
+        )
         body = '{}\nPlease read our guidelines at: {}'.format(body, url)
         if not args.quiet:
             print(body)
@@ -193,8 +202,9 @@ def _find_issue_mentions(message):
         issues.append(words[issue_location])
         # check whether issue is just being referred to
         if issue_location > 2:
-            preceding_2words = '{} {}'.format(words[issue_location - 2],
-                                              words[issue_location - 1])
+            preceding_2words = '{} {}'.format(
+                words[issue_location - 2], words[issue_location - 1]
+            )
             allowed_refs = [
                 'related to',
                 'refers to',
@@ -203,15 +213,7 @@ def _find_issue_mentions(message):
                 good_mentions += 1
                 continue
         # check whether issue is being closed
-        allowed_closure = [
-            'fix',
-            'fixes',
-            'close',
-            'closes'
-        ]
+        allowed_closure = ['fix', 'fixes', 'close', 'closes']
         if word.lower() in allowed_closure:
             good_mentions += 1
-    return {
-        'issues': issues,
-        'good_mentions': good_mentions
-    }
+    return {'issues': issues, 'good_mentions': good_mentions}

--- a/openwisp_utils/staticfiles.py
+++ b/openwisp_utils/staticfiles.py
@@ -12,6 +12,7 @@ class DependencyFinder(FileSystemFinder):
     A static files finder that finds static files of
     django-apps listed in dependencies
     """
+
     dependencies = list(EXTENDED_APPS) + ['openwisp_utils']
 
     def __init__(self, app_names=None, *args, **kwargs):

--- a/runtests.py
+++ b/runtests.py
@@ -9,6 +9,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
 if __name__ == "__main__":
     from django.core.management import execute_from_command_line
+
     args = sys.argv
     args.insert(1, "test")
     args.insert(2, "test_project")

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,11 @@ universal=1
 known_third_party = django,openwisp_utils
 default_section = THIRDPARTY
 skip = migrations
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
 
 [flake8]
 exclude = *migrations*,

--- a/setup.py
+++ b/setup.py
@@ -37,15 +37,16 @@ setup(
             'checkcommit = openwisp_utils.qa:check_commit_message',
         ],
     },
-    scripts=['openwisp-utils-qa-checks'],
+    scripts=['openwisp-qa-format', 'openwisp-utils-qa-checks'],
     include_package_data=True,
     zip_safe=False,
     install_requires=['django-model-utils>=4.0.0,<4.1.0'],
     extras_require={
         'qa': [
+            'black<=19.10b0',
             'flake8<=3.7.9',
             'isort<=4.3.21',
-            'coveralls'  # depends on coverage as well
+            'coveralls',  # depends on coverage as well
         ],
     },
     classifiers=[
@@ -58,5 +59,5 @@ setup(
         'Operating System :: OS Independent',
         'Framework :: Django',
         'Programming Language :: Python :: 3',
-    ]
+    ],
 )

--- a/tests/local_settings.example.py
+++ b/tests/local_settings.example.py
@@ -1,7 +1,7 @@
 # RENAME THIS FILE TO local_settings.py IF YOU NEED TO CUSTOMIZE SOME SETTINGS
 # BUT DO NOT COMMIT
 
-#DATABASES = {
+# DATABASES = {
 #    'default': {
 #        'ENGINE': 'django.db.backends.sqlite3',
 #        'NAME': 'openwisp_utils.db',
@@ -10,4 +10,4 @@
 #        'HOST': '',
 #        'PORT': ''
 #    },
-#}
+# }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -72,10 +72,7 @@ TEMPLATES = [
 ]
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'openwisp_utils.db',
-    }
+    'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'openwisp_utils.db',}
 }
 
 OPENWISP_ADMIN_SITE_CLASS = 'test_project.site.CustomAdminSite'
@@ -93,4 +90,3 @@ try:
     from local_settings import *
 except ImportError:
     pass
-

--- a/tests/test_project/admin.py
+++ b/tests/test_project/admin.py
@@ -1,8 +1,12 @@
 from django.contrib import admin
 from django.forms import ModelForm
-from openwisp_utils.admin import (AlwaysHasChangedMixin, ReadOnlyAdmin,
-                                  ReceiveUrlAdmin, TimeReadonlyAdminMixin,
-                                  UUIDAdmin)
+from openwisp_utils.admin import (
+    AlwaysHasChangedMixin,
+    ReadOnlyAdmin,
+    ReceiveUrlAdmin,
+    TimeReadonlyAdminMixin,
+    UUIDAdmin,
+)
 
 from .models import Operator, Project, RadiusAccounting, Shelf
 
@@ -32,8 +36,16 @@ class OperatorInline(admin.StackedInline):
 class ProjectAdmin(UUIDAdmin, ReceiveUrlAdmin):
     inlines = [OperatorInline]
     list_display = ('name',)
-    fields = ('uuid', 'name', 'key', 'receive_url',)
-    readonly_fields = ('uuid', 'receive_url',)
+    fields = (
+        'uuid',
+        'name',
+        'key',
+        'receive_url',
+    )
+    readonly_fields = (
+        'uuid',
+        'receive_url',
+    )
     receive_url_name = 'receive_project'
 
 

--- a/tests/test_project/migrations/0001_initial.py
+++ b/tests/test_project/migrations/0001_initial.py
@@ -11,58 +11,148 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
             name='Project',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('name', models.CharField(blank=True, max_length=64, null=True)),
             ],
         ),
         migrations.CreateModel(
             name='RadiusAccounting',
             fields=[
-                ('id', models.BigAutoField(db_column='radacctid', primary_key=True, serialize=False)),
-                ('session_id', models.CharField(db_column='acctsessionid', db_index=True, max_length=64, verbose_name='session ID')),
-                ('username', models.CharField(blank=True, db_index=True, max_length=64, null=True, verbose_name='username')),
+                (
+                    'id',
+                    models.BigAutoField(
+                        db_column='radacctid', primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    'session_id',
+                    models.CharField(
+                        db_column='acctsessionid',
+                        db_index=True,
+                        max_length=64,
+                        verbose_name='session ID',
+                    ),
+                ),
+                (
+                    'username',
+                    models.CharField(
+                        blank=True,
+                        db_index=True,
+                        max_length=64,
+                        null=True,
+                        verbose_name='username',
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
             name='Shelf',
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
-                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, editable=False, verbose_name='created')),
-                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, editable=False, verbose_name='modified')),
+                (
+                    'id',
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    'created',
+                    model_utils.fields.AutoCreatedField(
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name='created',
+                    ),
+                ),
+                (
+                    'modified',
+                    model_utils.fields.AutoLastModifiedField(
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name='modified',
+                    ),
+                ),
                 ('name', models.CharField(max_length=64, verbose_name='name')),
             ],
-            options={
-                'abstract': False,
-            },
+            options={'abstract': False,},
         ),
         migrations.CreateModel(
             name='Operator',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('first_name', models.CharField(default='test', max_length=30)),
                 ('last_name', models.CharField(default='test', max_length=30)),
-                ('project', models.ForeignKey(blank=True, on_delete=django.db.models.deletion.CASCADE, to='test_project.Project')),
+                (
+                    'project',
+                    models.ForeignKey(
+                        blank=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to='test_project.Project',
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
             name='Book',
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
-                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, editable=False, verbose_name='created')),
-                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, editable=False, verbose_name='modified')),
+                (
+                    'id',
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    'created',
+                    model_utils.fields.AutoCreatedField(
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name='created',
+                    ),
+                ),
+                (
+                    'modified',
+                    model_utils.fields.AutoLastModifiedField(
+                        default=django.utils.timezone.now,
+                        editable=False,
+                        verbose_name='modified',
+                    ),
+                ),
                 ('name', models.CharField(max_length=64, verbose_name='name')),
                 ('author', models.CharField(max_length=64, verbose_name='author')),
-                ('shelf', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='test_project.Shelf')),
+                (
+                    'shelf',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to='test_project.Shelf',
+                    ),
+                ),
             ],
-            options={
-                'abstract': False,
-            },
+            options={'abstract': False,},
         ),
     ]

--- a/tests/test_project/migrations/0002_add_key_id_project.py
+++ b/tests/test_project/migrations/0002_add_key_id_project.py
@@ -18,11 +18,26 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='project',
             name='key',
-            field=openwisp_utils.base.KeyField(db_index=True, default=openwisp_utils.utils.get_random_key, help_text='unique project key', max_length=64, unique=True, validators=[django.core.validators.RegexValidator(re.compile('^[^\\s/\\.]+$'), code='invalid', message='This value must not contain spaces, dots or slashes.')]),
+            field=openwisp_utils.base.KeyField(
+                db_index=True,
+                default=openwisp_utils.utils.get_random_key,
+                help_text='unique project key',
+                max_length=64,
+                unique=True,
+                validators=[
+                    django.core.validators.RegexValidator(
+                        re.compile('^[^\\s/\\.]+$'),
+                        code='invalid',
+                        message='This value must not contain spaces, dots or slashes.',
+                    )
+                ],
+            ),
         ),
         migrations.AlterField(
             model_name='project',
             name='id',
-            field=models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False),
+            field=models.UUIDField(
+                default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+            ),
         ),
     ]

--- a/tests/test_project/models.py
+++ b/tests/test_project/models.py
@@ -33,24 +33,20 @@ class Book(TimeStampedEditableModel):
 
 class RadiusAccounting(models.Model):
     id = models.BigAutoField(primary_key=True, db_column='radacctid')
-    session_id = models.CharField(verbose_name=_('session ID'),
-                                  max_length=64,
-                                  db_column='acctsessionid',
-                                  db_index=True)
-    username = models.CharField(verbose_name=_('username'),
-                                max_length=64,
-                                db_index=True,
-                                null=True,
-                                blank=True)
+    session_id = models.CharField(
+        verbose_name=_('session ID'),
+        max_length=64,
+        db_column='acctsessionid',
+        db_index=True,
+    )
+    username = models.CharField(
+        verbose_name=_('username'), max_length=64, db_index=True, null=True, blank=True
+    )
 
 
 class Project(UUIDModel):
-    name = models.CharField(max_length=64,
-                            null=True,
-                            blank=True)
-    key = KeyField(unique=True,
-                   db_index=True,
-                   help_text=_('unique project key'))
+    name = models.CharField(max_length=64, null=True, blank=True)
+    key = KeyField(unique=True, db_index=True, help_text=_('unique project key'))
 
     def __str__(self):
         return self.name

--- a/tests/test_project/test_api/urls.py
+++ b/tests/test_project/test_api/urls.py
@@ -3,7 +3,9 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^receive_project/(?P<pk>[^/\?]+)/$',
+    url(
+        r'^receive_project/(?P<pk>[^/\?]+)/$',
         views.receive_project,
-        name='receive_project'),
+        name='receive_project',
+    ),
 ]

--- a/tests/test_project/test_api/views.py
+++ b/tests/test_project/test_api/views.py
@@ -16,14 +16,11 @@ class ReceiveProjectView(View):
         try:
             project = Project.objects.get(pk=pk)
         except Project.DoesNotExist:
-            return JsonResponse({'detail': _('project not found')},
-                                status=400)
+            return JsonResponse({'detail': _('project not found')}, status=400)
         key = request.GET.get('key')
         if project.key != key:
-            return JsonResponse({'detail': _('wrong key')},
-                                status=403)
-        return JsonResponse({'detail': _('ok'), 'name': project.name},
-                            status=200)
+            return JsonResponse({'detail': _('wrong key')}, status=403)
+        return JsonResponse({'detail': _('ok'), 'name': project.name}, status=200)
 
 
 receive_project = ReceiveProjectView.as_view()

--- a/tests/test_project/tests/__init__.py
+++ b/tests/test_project/tests/__init__.py
@@ -1,7 +1,6 @@
 class CreateMixin(object):
     def _create_book(self, **kwargs):
-        options = dict(name='test-book',
-                       author='test-author')
+        options = dict(name='test-book', author='test-author')
         options.update(kwargs)
         b = self.book_model(**options)
         b.full_clean()

--- a/tests/test_project/tests/test_admin.py
+++ b/tests/test_project/tests/test_admin.py
@@ -18,18 +18,18 @@ class TestAdmin(TestCase, CreateMixin):
     accounting_model = RadiusAccounting
 
     def setUp(self):
-        user = User.objects.create_superuser(username='administrator',
-                                             password='admin',
-                                             email='test@test.org')
+        user = User.objects.create_superuser(
+            username='administrator', password='admin', email='test@test.org'
+        )
         self.client.force_login(user)
         self.site = AdminSite()
 
     def test_radiusaccounting_change(self):
         options = dict(username='bobby', session_id='1')
         obj = self._create_radius_accounting(**options)
-        response = self.client.get(reverse(
-                                   'admin:test_project_radiusaccounting_change',
-                                   args=[obj.pk]))
+        response = self.client.get(
+            reverse('admin:test_project_radiusaccounting_change', args=[obj.pk])
+        )
         self.assertContains(response, 'ok')
         self.assertNotContains(response, 'errors')
 
@@ -54,8 +54,7 @@ class TestAdmin(TestCase, CreateMixin):
             'operator_set-0-id': '',
         }
         url = reverse('admin:test_project_project_add')
-        r = self.client.post(url, params,
-                             follow=True)
+        r = self.client.post(url, params, follow=True)
         self.assertNotContains(r, 'error')
         self.assertEqual(Project.objects.count(), 1)
         self.assertEqual(Operator.objects.count(), 1)
@@ -130,40 +129,65 @@ class TestAdmin(TestCase, CreateMixin):
 
     def test_admin_theme_css_setting(self):
         # test for improper configuration : not a list
-        setattr(admin_theme_settings, 'OPENWISP_ADMIN_THEME_LINKS', 'string instead of list')
-        self.assertIn('OPENWISP_ADMIN_THEME_LINKS',
-                      str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]))
+        setattr(
+            admin_theme_settings, 'OPENWISP_ADMIN_THEME_LINKS', 'string instead of list'
+        )
+        self.assertIn(
+            'OPENWISP_ADMIN_THEME_LINKS',
+            str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]),
+        )
         # test for improper configuration : list_elements != type(dict)
-        setattr(admin_theme_settings, 'OPENWISP_ADMIN_THEME_LINKS',
-                ['/static/custom-admin-theme.css'])
-        self.assertIn('OPENWISP_ADMIN_THEME_LINKS',
-                      str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]))
+        setattr(
+            admin_theme_settings,
+            'OPENWISP_ADMIN_THEME_LINKS',
+            ['/static/custom-admin-theme.css'],
+        )
+        self.assertIn(
+            'OPENWISP_ADMIN_THEME_LINKS',
+            str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]),
+        )
         # test for improper configuration: dict missing required keys
         setattr(admin_theme_settings, 'OPENWISP_ADMIN_THEME_LINKS', [{'wrong': True}])
-        self.assertIn('OPENWISP_ADMIN_THEME_LINKS',
-                      str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]))
+        self.assertIn(
+            'OPENWISP_ADMIN_THEME_LINKS',
+            str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]),
+        )
         # test with desired configuration
-        setattr(admin_theme_settings, 'OPENWISP_ADMIN_THEME_LINKS',
-                [{
+        setattr(
+            admin_theme_settings,
+            'OPENWISP_ADMIN_THEME_LINKS',
+            [
+                {
                     'href': '/static/custom-admin-theme.css',
                     'rel': 'stylesheet',
                     'type': 'text/css',
-                    'media': 'all'
-                }])
+                    'media': 'all',
+                }
+            ],
+        )
         response = self.client.get(reverse('admin:index'))
         self.assertContains(response, '/static/custom-admin-theme.css" media="all"')
 
     def test_admin_theme_js_setting(self):
         # test for improper configuration : not a list
-        setattr(admin_theme_settings, 'OPENWISP_ADMIN_THEME_JS', 'string instead of list')
-        self.assertIn('OPENWISP_ADMIN_THEME_JS',
-                      str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]))
+        setattr(
+            admin_theme_settings, 'OPENWISP_ADMIN_THEME_JS', 'string instead of list'
+        )
+        self.assertIn(
+            'OPENWISP_ADMIN_THEME_JS',
+            str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]),
+        )
         # test for improper configuration : list_elements != type(str)
         setattr(admin_theme_settings, 'OPENWISP_ADMIN_THEME_JS', [0, 1, 2])
-        self.assertIn('OPENWISP_ADMIN_THEME_JS',
-                      str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]))
+        self.assertIn(
+            'OPENWISP_ADMIN_THEME_JS',
+            str(admin_theme_settings_checks(OpenWispAdminThemeConfig)[0]),
+        )
         # test with desired configuration
-        setattr(admin_theme_settings, 'OPENWISP_ADMIN_THEME_JS',
-                ['/static/openwisp-utils/js/uuid.js'])
+        setattr(
+            admin_theme_settings,
+            'OPENWISP_ADMIN_THEME_JS',
+            ['/static/openwisp-utils/js/uuid.js'],
+        )
         response = self.client.get(reverse('admin:index'))
         self.assertContains(response, 'src="/static/openwisp-utils/js/uuid.js"')

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -7,7 +7,9 @@ from unittest.mock import patch
 from django.test import TestCase
 from openwisp_utils.qa import check_commit_message, check_migration_name
 
-MIGRATIONS_DIR = path.join(path.dirname(path.dirname(path.abspath(__file__))), 'migrations')
+MIGRATIONS_DIR = path.join(
+    path.dirname(path.dirname(path.abspath(__file__))), 'migrations'
+)
 
 
 class TestQa(TestCase):
@@ -23,9 +25,11 @@ class TestQa(TestCase):
     def test_qa_call_check_migration_name_pass(self):
         options = [
             'checkmigrations',
-            '--migrations-to-ignore', '2',
-            '--migration-path', MIGRATIONS_DIR,
-            '--quiet'
+            '--migrations-to-ignore',
+            '2',
+            '--migration-path',
+            MIGRATIONS_DIR,
+            '--quiet',
         ]
         with patch('argparse._sys.argv', options):
             try:
@@ -37,16 +41,14 @@ class TestQa(TestCase):
         options = [
             [
                 'checkmigrations',
-                '--migrations-to-ignore', '1',
-                '--migration-path', MIGRATIONS_DIR,
-                '--quiet'
+                '--migrations-to-ignore',
+                '1',
+                '--migration-path',
+                MIGRATIONS_DIR,
+                '--quiet',
             ],
-            [
-                'checkmigrations',
-                '--migration-path', MIGRATIONS_DIR,
-                '--quiet'
-            ],
-            ['checkmigrations']
+            ['checkmigrations', '--migration-path', MIGRATIONS_DIR, '--quiet'],
+            ['checkmigrations'],
         ]
         for option in options:
             with patch('argparse._sys.argv', option):
@@ -60,7 +62,8 @@ class TestQa(TestCase):
     def test_migration_failure_message(self):
         bad_migration = [
             'checkmigrations',
-            '--migration-path', MIGRATIONS_DIR,
+            '--migration-path',
+            MIGRATIONS_DIR,
         ]
         with patch('argparse._sys.argv', bad_migration):
             captured_output = io.StringIO()
@@ -77,123 +80,104 @@ class TestQa(TestCase):
 
     def test_qa_call_check_commit_message_pass(self):
         options = [
+            ['commitcheck', '--quiet', '--message', "[qa] Minor clean up operations"],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "[qa] Minor clean up operations"
-            ],
-            [
-                'commitcheck',
-                '--quiet', '--message',
+                '--quiet',
+                '--message',
                 "[qa] Updated more file and fix problem #20\n\n"
-                "Added more files Fixes #20"
+                "Added more files Fixes #20",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "[qa] Improved Y #2\n\n"
-                "Related to #2"
+                '--quiet',
+                '--message',
+                "[qa] Improved Y #2\n\n" "Related to #2",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "[qa] Finished task #2\n\n"
-                "Closes #2\nRelated to #1"
+                '--quiet',
+                '--message',
+                "[qa] Finished task #2\n\n" "Closes #2\nRelated to #1",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "[qa] Finished task #2\n\n"
-                "Related to #2\nCloses #1"
+                '--quiet',
+                '--message',
+                "[qa] Finished task #2\n\n" "Related to #2\nCloses #1",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "[qa] Finished task #2\n\n"
-                "Related to #2\nRelated to #1"
+                '--quiet',
+                '--message',
+                "[qa] Finished task #2\n\n" "Related to #2\nRelated to #1",
             ],
             # noqa
             [
                 'commitcheck',
-                '--quiet', '--message',
+                '--quiet',
+                '--message',
                 "[qa] Improved Y #20\n\n"
-                "Simulation of a special unplanned case\n\n#noqa"
-            ]
+                "Simulation of a special unplanned case\n\n#noqa",
+            ],
         ]
         for option in options:
             with patch('argparse._sys.argv', option):
                 try:
                     check_commit_message()
                 except (SystemExit, Exception) as e:
-                    msg = 'Check failed:\n\n{}' \
-                          '\n\nOutput:{}'.format(option[-1], e)
+                    msg = 'Check failed:\n\n{}' '\n\nOutput:{}'.format(option[-1], e)
                     self.fail(msg)
 
     def test_qa_call_check_commit_message_failure(self):
         options = [
             ['commitcheck'],
+            ['commitcheck', '--quiet', '--message', 'Hello World'],
+            ['commitcheck', '--quiet', '--message', '[qa] hello World'],
+            ['commitcheck', '--quiet', '--message', '[qa] Hello World.'],
+            ['commitcheck', '--quiet', '--message', '[qa] Hello World.\nFixes #20'],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                'Hello World',
+                '--quiet',
+                '--message',
+                "[qa] Fixed problem #20" "\n\nFixed problem X #20",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                '[qa] hello World',
+                '--quiet',
+                '--message',
+                "[qa] Finished task #2\n\n" "Resolves problem described in #2",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                '[qa] Hello World.',
+                '--quiet',
+                '--message',
+                "[qa] Fixed problem\n\n" "Failure #2\nRelated to #1",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                '[qa] Hello World.\nFixes #20',
+                '--quiet',
+                '--message',
+                "[qa] Updated file and fixed problem\n\n" "Added more files. Fixes #20",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "[qa] Fixed problem #20"
-                "\n\nFixed problem X #20"
+                '--quiet',
+                '--message',
+                "[qa] Improved Y\n\n" "Related to #2",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "[qa] Finished task #2\n\n"
-                "Resolves problem described in #2"
+                '--quiet',
+                '--message',
+                "[qa] Improved Y #2\n\n" "Updated files",
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "[qa] Fixed problem\n\n"
-                "Failure #2\nRelated to #1"
+                '--quiet',
+                '--message',
+                "[qa] Improved Y #20\n\n" "Related to #32 Fixes #30 Fix #40",
             ],
-            [
-                'commitcheck',
-                '--quiet', '--message',
-                "[qa] Updated file and fixed problem\n\n"
-                "Added more files. Fixes #20"
-            ],
-            [
-                'commitcheck',
-                '--quiet', '--message',
-                "[qa] Improved Y\n\n"
-                "Related to #2"
-            ],
-            [
-                'commitcheck',
-                '--quiet', '--message',
-                "[qa] Improved Y #2\n\n"
-                "Updated files"
-            ],
-            [
-                'commitcheck',
-                '--quiet', '--message',
-                "[qa] Improved Y #20\n\n"
-                "Related to #32 Fixes #30 Fix #40"
-            ]
         ]
         for option in options:
             with patch('argparse._sys.argv', option):
@@ -208,8 +192,7 @@ class TestQa(TestCase):
         bad_commit = [
             'commitcheck',
             '--message',
-            "[qa] Updated file and fixed problem\n\n"
-            "Added more files. Fixes #20"
+            "[qa] Updated file and fixed problem\n\n" "Added more files. Fixes #20",
         ]
         with patch('argparse._sys.argv', bad_commit):
             captured_output = io.StringIO()
@@ -228,14 +211,16 @@ class TestQa(TestCase):
         options = [
             [
                 'commitcheck',
-                '--quiet', '--message',
+                '--quiet',
+                '--message',
                 'Merge pull request #17 from TheOneAboveAllTitan/issues/16\n\n'
-                '[monitoring] Added migration to create ping for existing devices. #16'
+                '[monitoring] Added migration to create ping for existing devices. #16',
             ],
             [
                 'commitcheck',
-                '--quiet', '--message',
-                "Merge branch 'issue-21' into master"
+                '--quiet',
+                '--message',
+                "Merge branch 'issue-21' into master",
             ],
         ]
         for option in options:
@@ -243,6 +228,5 @@ class TestQa(TestCase):
                 try:
                     check_commit_message()
                 except (SystemExit, Exception) as e:
-                    msg = 'Check failed:\n\n{}' \
-                          '\n\nOutput:{}'.format(option[-1], e)
+                    msg = 'Check failed:\n\n{}' '\n\nOutput:{}'.format(option[-1], e)
                     self.fail(msg)

--- a/tests/test_project/tests/test_test_utils.py
+++ b/tests/test_project/tests/test_test_utils.py
@@ -7,14 +7,11 @@ status_signal = Signal(providing_args=['status'])
 
 class TestUtils(TestCase):
     def _generate_signal(self):
-        status_signal.send(sender=self,
-                           status='working')
+        status_signal.send(sender=self, status='working')
 
     def test_status_signal_emitted(self):
         with catch_signal(status_signal) as handler:
             self._generate_signal()
         handler.assert_called_once_with(
-            status='working',
-            sender=self,
-            signal=status_signal,
+            status='working', sender=self, signal=status_signal,
         )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,5 +4,5 @@ from django.urls import include
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^test_api/', include('test_project.test_api.urls'))
+    url(r'^test_api/', include('test_project.test_api.urls')),
 ]


### PR DESCRIPTION
This allows us to define a common code formatting standard and avoids
having to manually do these changes manually.
It is enabled by default and can be disabled using --skip-black
This PR also formats the code in this repository using black.
Also added flag --force-checkcommit to force the commit message check

Fixes #86