### PR TITLE
[checks] Fix crash when pending migrations check fails #95

### DIFF
--- a/openwisp-utils-qa-checks
+++ b/openwisp-utils-qa-checks
@@ -115,7 +115,7 @@ runcheckpendingmigrations() {
     echo $OUTPUT
     echo $OUTPUT | grep "No changes detected" &> /dev/null \
       && echo "SUCCESS: Migrations check successful!" \
-      || { echoerr "ERROR: Migrations check failed! Models' changes not migrated, please run `./manage.py makemigrations` to solve the issue!"; FAILURE=1; }
+      || { echoerr "ERROR: Migrations check failed! Models' changes not migrated, please run './manage.py makemigrations' to solve the issue!"; FAILURE=1; }
   fi
 }
 


### PR DESCRIPTION
The line contains backticks, making the script to interpret it as
a command to be run and fail because manage.py is not expected
to be there. See this travis log

Fixes #95