### PR TITLE
[api] Implement ScopedRateThrottle by default

### DIFF
--- a/openwisp_utils/__init__.py
+++ b/openwisp_utils/__init__.py
@@ -16,3 +16,6 @@ def get_version():
                 rev = 0
             version = '%s%s%s' % (version, VERSION[3][0:1], rev)
     return version
+
+
+default_app_config = 'openwisp_utils.apps.UtilsAppConfig'

--- a/openwisp_utils/apps.py
+++ b/openwisp_utils/apps.py
@@ -1,0 +1,23 @@
+from django.apps import AppConfig
+from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
+
+
+class UtilsAppConfig(AppConfig):
+    name = 'openwisp_utils'
+    label = 'utils'
+    verbose_name = _('OpenWISP utils')
+
+    DEFAULT_REST_FRAMEWORK = {
+        'DEFAULT_THROTTLE_CLASSES': ['rest_framework.throttling.ScopedRateThrottle'],
+        'DEFAULT_THROTTLE_RATES': {'anon': '40/hour'},
+    }
+
+    def ready(self, *args, **kwargs):
+        self.configure_drf_defaults()
+
+    def configure_drf_defaults(self):
+        config = getattr(settings, 'REST_FRAMEWORK', {})
+        for key in self.DEFAULT_REST_FRAMEWORK.keys():
+            config.setdefault(key, self.DEFAULT_REST_FRAMEWORK[key])
+        setattr(settings, 'REST_FRAMEWORK', config)

--- a/openwisp_utils/settings.py
+++ b/openwisp_utils/settings.py
@@ -13,3 +13,5 @@ API_INFO = getattr(
         'description': 'OpenWISP REST API',
     },
 )
+
+API_RATE_ANON = getattr(settings, 'OPENWISP_API_RATE_ANON', '40/hour')

--- a/openwisp_utils/settings.py
+++ b/openwisp_utils/settings.py
@@ -13,5 +13,3 @@ API_INFO = getattr(
         'description': 'OpenWISP REST API',
     },
 )
-
-API_RATE_ANON = getattr(settings, 'OPENWISP_API_RATE_ANON', '40/hour')

--- a/tests/test_project/apps.py
+++ b/tests/test_project/apps.py
@@ -1,18 +1,14 @@
 from django.apps import AppConfig
 from django.conf import settings
 
-from openwisp_utils import settings as app_settings
-
 
 class TestAppConfig(AppConfig):
     name = 'test_project'
     label = 'test_project'
 
-    _default_drf = {
+    DEFAULT_REST_FRAMEWORK = {
         'DEFAULT_THROTTLE_CLASSES': ['rest_framework.throttling.ScopedRateThrottle'],
-        'DEFAULT_THROTTLE_RATES': {
-            'anon': app_settings.API_RATE_ANON,
-        },
+        'DEFAULT_THROTTLE_RATES': {'anon': '40/hour'},
     }
 
     def ready(self, *args, **kwargs):
@@ -29,5 +25,6 @@ class TestAppConfig(AppConfig):
 
     def configure_drf_defaults(self):
         config = getattr(settings, 'REST_FRAMEWORK', {})
-        config.update(self._default_drf)
+        for key in self.DEFAULT_REST_FRAMEWORK.keys():
+            config.setdefault(key, self.DEFAULT_REST_FRAMEWORK[key])
         setattr(settings, 'REST_FRAMEWORK', config)

--- a/tests/test_project/apps.py
+++ b/tests/test_project/apps.py
@@ -1,14 +1,24 @@
 from django.apps import AppConfig
 from django.conf import settings
 
+from openwisp_utils import settings as app_settings
+
 
 class TestAppConfig(AppConfig):
     name = 'test_project'
     label = 'test_project'
 
+    _default_drf = {
+        'DEFAULT_THROTTLE_CLASSES': ['rest_framework.throttling.ScopedRateThrottle'],
+        'DEFAULT_THROTTLE_RATES': {
+            'anon': app_settings.API_RATE_ANON,
+        },
+    }
+
     def ready(self, *args, **kwargs):
         super(TestAppConfig, self).ready(*args, **kwargs)
         self.add_default_menu_items()
+        self.configure_drf_defaults()
 
     def add_default_menu_items(self):
         menu_setting = 'OPENWISP_DEFAULT_ADMIN_MENU_ITEMS'
@@ -16,3 +26,8 @@ class TestAppConfig(AppConfig):
             {'model': 'test_project.Shelf'},
         ]
         setattr(settings, menu_setting, items)
+
+    def configure_drf_defaults(self):
+        config = getattr(settings, 'REST_FRAMEWORK', {})
+        config.update(self._default_drf)
+        setattr(settings, 'REST_FRAMEWORK', config)


### PR DESCRIPTION
This PR is part of https://github.com/openwisp/openwisp-firmware-upgrader/issues/48

Note that by using ScopedRateThrottling it requires us to define a default anon class throttle for the unauthenticated API requests.