### PR TITLE
[admin-theme] menu doesn't respect assigned permissions #103

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,9 +233,7 @@ template ``context_processors`` in ``settings.py`` as shown below.
 If you need to define custom menu items, see:
 `OPENWISP_ADMIN_MENU_ITEMS <#openwisp_admin_menu_items>`_.
 
-Superusers can see all menu items while other users can only see menu items
-for modules on which they have permissions.
-
+Users will only be able to see menu items for objects they have permission to either view or edit.
 
 Model utilities
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -233,6 +233,10 @@ template ``context_processors`` in ``settings.py`` as shown below.
 If you need to define custom menu items, see:
 `OPENWISP_ADMIN_MENU_ITEMS <#openwisp_admin_menu_items>`_.
 
+Superusers can see all menu items while other users can only see menu items
+for modules on which they have permissions.
+
+
 Model utilities
 ---------------
 


### PR DESCRIPTION
Fixed issue by making sure users can access just the models
they are permitted to access.

Fixes #103
Closes #104