### PR TITLE
[docs] Fixed command not installing dependencies in development environment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -701,7 +701,7 @@ Install your forked repo:
 
     git clone git://github.com/<your_fork>/openwisp-utils
     cd openwisp-utils/
-    python setup.py develop
+    pip install -e .[qa,rest]
 
 Install test requirements:
 


### PR DESCRIPTION
Replaced `python setup.py develop` with `pip install -e .[qa,rest]` for developmet version.

Closes #114