### PR TITLE
[fix] Fixed commit message check missing close/fix keyword #136

### DIFF
--- a/openwisp_utils/qa.py
+++ b/openwisp_utils/qa.py
@@ -113,6 +113,8 @@ def check_commit_message():
         suffix = short_desc.replace(prefix.group(), '').strip()
         if not suffix[0].isupper():
             errors.append('please add a capital letter after the prefix')
+    # default issue mentions
+    issues = []
     # ensure there's a blank line between short and long desc
     if long_desc:
         if len(lines) > 1 and lines[1] != '':
@@ -145,22 +147,22 @@ def check_commit_message():
                     'eg: [prefix] Action performed #234\n\n      '
                     'Long desc. Closes #234'
                 )
-        # if short description mentions an issue
-        # ensure the issue is either closed or mentioned as "related"
-        if re.search(r'\#(\d+)', short_desc):
-            mentions = 0
-            for issue in issues:
-                if re.search(r'\{}'.format(issue), short_desc):
-                    mentions += 1
-            if mentions < 1:
-                errors.append(
-                    'You are mentioning an issue in the short description '
-                    'but it is not clear whether the issue is resolved or not;\n  '
-                    'if it is resolved, please add to the commit long description:\n  '
-                    '"Closes #<issue-number>" or "Fixes #<issue-number>";\n  '
-                    'if the issue is not resolved yet, please use the following form:\n  '
-                    '"Related to #<issue-number>"'
-                )
+    # if short description mentions an issue
+    # ensure the issue is either closed or mentioned as "related"
+    if re.search(r'\#(\d+)', short_desc):
+        mentions = 0
+        for issue in issues:
+            if re.search(r'\{}'.format(issue), short_desc):
+                mentions += 1
+        if mentions < 1:
+            errors.append(
+                'You are mentioning an issue in the short description '
+                'but it is not clear whether the issue is resolved or not;\n  '
+                'if it is resolved, please add to the commit long description:\n  '
+                '"Closes #<issue-number>" or "Fixes #<issue-number>";\n  '
+                'if the issue is not resolved yet, please use the following form:\n  '
+                '"Related to #<issue-number>"'
+            )
     # fail in case of error
     if len(errors):
         body = (

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -178,7 +178,8 @@ class TestQa(TestCase):
                 '--message',
                 '[qa] Improved Y #20\n\nRelated to #32 Fixes #30 Fix #40',
             ],
-            ],
+            # issue 136
+            ['commitcheck', '--quiet', '--message', '[qa] Fixed issue #20'],
         ]
         for option in options:
             with patch('argparse._sys.argv', option):

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -80,45 +80,45 @@ class TestQa(TestCase):
 
     def test_qa_call_check_commit_message_pass(self):
         options = [
-            ['commitcheck', '--quiet', '--message', "[qa] Minor clean up operations"],
+            ['commitcheck', '--quiet', '--message', '[qa] Minor clean up operations'],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Updated more file and fix problem #20\n\n"
-                "Added more files Fixes #20",
+                '[qa] Updated more file and fix problem #20\n\n'
+                'Added more files Fixes #20',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Improved Y #2\n\n" "Related to #2",
+                '[qa] Improved Y #2\n\nRelated to #2',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Finished task #2\n\n" "Closes #2\nRelated to #1",
+                '[qa] Finished task #2\n\nCloses #2\nRelated to #1',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Finished task #2\n\n" "Related to #2\nCloses #1",
+                '[qa] Finished task #2\n\nRelated to #2\nCloses #1',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Finished task #2\n\n" "Related to #2\nRelated to #1",
+                '[qa] Finished task #2\n\nRelated to #2\nRelated to #1',
             ],
             # noqa
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Improved Y #20\n\n"
-                "Simulation of a special unplanned case\n\n#noqa",
+                '[qa] Improved Y #20\n\n'
+                'Simulation of a special unplanned case\n\n#noqa',
             ],
         ]
         for option in options:
@@ -126,7 +126,7 @@ class TestQa(TestCase):
                 try:
                     check_commit_message()
                 except (SystemExit, Exception) as e:
-                    msg = 'Check failed:\n\n{}' '\n\nOutput:{}'.format(option[-1], e)
+                    msg = 'Check failed:\n\n{}\n\nOutput:{}'.format(option[-1], e)
                     self.fail(msg)
 
     def test_qa_call_check_commit_message_failure(self):
@@ -140,43 +140,44 @@ class TestQa(TestCase):
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Fixed problem #20" "\n\nFixed problem X #20",
+                '[qa] Fixed problem #20\n\nFixed problem X #20',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Finished task #2\n\n" "Resolves problem described in #2",
+                '[qa] Finished task #2\n\nResolves problem described in #2',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Fixed problem\n\n" "Failure #2\nRelated to #1",
+                '[qa] Fixed problem\n\nFailure #2\nRelated to #1',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Updated file and fixed problem\n\n" "Added more files. Fixes #20",
+                '[qa] Updated file and fixed problem\n\nAdded more files. Fixes #20',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Improved Y\n\n" "Related to #2",
+                '[qa] Improved Y\n\nRelated to #2',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Improved Y #2\n\n" "Updated files",
+                '[qa] Improved Y #2\n\nUpdated files',
             ],
             [
                 'commitcheck',
                 '--quiet',
                 '--message',
-                "[qa] Improved Y #20\n\n" "Related to #32 Fixes #30 Fix #40",
+                '[qa] Improved Y #20\n\nRelated to #32 Fixes #30 Fix #40',
+            ],
             ],
         ]
         for option in options:
@@ -192,7 +193,7 @@ class TestQa(TestCase):
         bad_commit = [
             'commitcheck',
             '--message',
-            "[qa] Updated file and fixed problem\n\n" "Added more files. Fixes #20",
+            '[qa] Updated file and fixed problem\n\nAdded more files. Fixes #20',
         ]
         with patch('argparse._sys.argv', bad_commit):
             captured_output = io.StringIO()
@@ -228,7 +229,7 @@ class TestQa(TestCase):
                 try:
                     check_commit_message()
                 except (SystemExit, Exception) as e:
-                    msg = 'Check failed:\n\n{}' '\n\nOutput:{}'.format(option[-1], e)
+                    msg = 'Check failed:\n\n{}\n\nOutput:{}'.format(option[-1], e)
                     self.fail(msg)
 
     def test_qa_call_check_commit_message_bump_version(self):
@@ -241,5 +242,5 @@ class TestQa(TestCase):
                 try:
                     check_commit_message()
                 except (SystemExit, Exception) as e:
-                    msg = 'Check failed:\n\n{}' '\n\nOutput:{}'.format(option[-1], e)
+                    msg = 'Check failed:\n\n{}\n\nOutput:{}'.format(option[-1], e)
                     self.fail(msg)


### PR DESCRIPTION
Added failing test + fix.

Expecting build to fail, I sent a commit message which should trigger the failure on purpose to ensure it works.