### PR TITLE
[feature] Added a Custom Static Storage 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1087,7 +1087,7 @@ Allows to pass a list of **Unix shell-style wildcards** for files to be excluded
 
 Use Unix shell-style wildcards.
 
-Example Usage:
+Example usage:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -1083,7 +1083,7 @@ to detect slow tests (0.3s by default) and highlight the slowest ones (1s by def
 
 **default**: ``[]``
 
-Allows to pass a list of file types to be excluded by `CompressStaticFilesStorage <#openwisp_utilsstorageCompressStaticFilesStorage>`_.
+Allows to pass a list of **Unix shell-style wildcards** for files to be excluded by `CompressStaticFilesStorage <#openwisp_utilsstorageCompressStaticFilesStorage>`_.
 
 Use Unix shell-style wildcards.
 

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Current features
 * `Configurable navigation menu <#main-navigation-menu>`_
 * `OpenAPI / Swagger documentation <#openwisp_api_docs>`_
 * `Model utilities <#model-utilities>`_
+* `Storage utilities <#storage-utilities>`_
 * `Admin utilities <#admin-utilities>`_
 * `Code utilities <#code-utilities>`_
 * `REST API utilities <#rest-api-utilities>`_
@@ -618,6 +619,22 @@ Extends ``collections.SortedDict`` and implements logic to sort inserted
 items based on ``key`` value. Sorting is done at insert operation which
 incurs memory space overhead.
 
+Storage utilities
+-----------------
+
+``openwisp_utils.storage.CompressStaticFilesStorage``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A static storage backend for compression inheriting from `django-compress-staticfiles's <https://pypi.org/project/django-compress-staticfiles/>`_ ``CompressStaticFilesStorage`` class.
+
+Adds support for excluding file types using `OPENWISP_STATICFILES_VERSIONED_EXCLUDE <#openwisp_staticfiles_versioned_exclude>`_ setting.
+
+To use point ``STATICFILES_STORAGE`` to ``openwisp_utils.storage.CompressStaticFilesStorage`` in ``settings.py``.
+
+.. code-block:: python
+
+    STATICFILES_STORAGE = 'openwisp_utils.storage.CompressStaticFilesStorage'
+
 REST API utilities
 ------------------
 
@@ -1060,6 +1077,23 @@ For more information about optional parameters check the
 
 It can be used to change the thresholds used by `TimeLoggingTestRunner <#openwisp_utilsteststimeloggingtestrunner>`_
 to detect slow tests (0.3s by default) and highlight the slowest ones (1s by default) amongst them.
+
+``OPENWISP_STATICFILES_VERSIONED_EXCLUDE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**default**: ``[]``
+
+Allows to pass a list of file types to be excluded by `CompressStaticFilesStorage <#openwisp_utilsstorageCompressStaticFilesStorage>`_.
+
+Use Unix shell-style wildcards.
+
+Example Usage:
+
+.. code-block:: python
+
+    OPENWISP_STATICFILES_VERSIONED_EXCLUDE = [
+    '*png',
+    ]
 
 Installing for development
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -1081,9 +1081,11 @@ to detect slow tests (0.3s by default) and highlight the slowest ones (1s by def
 ``OPENWISP_STATICFILES_VERSIONED_EXCLUDE``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**default**: ``[]``
+**default**: ``['leaflet/*/*.png']``
 
 Allows to pass a list of **Unix shell-style wildcards** for files to be excluded by `CompressStaticFilesStorage <#openwisp_utilsstorageCompressStaticFilesStorage>`_.
+
+By default Leaflet PNGs have been excluded to avoid bugs like `openwisp/ansible-openwisp2#232 <https://github.com/openwisp/ansible-openwisp2/issues/232>`_
 
 Example usage:
 

--- a/README.rst
+++ b/README.rst
@@ -1085,7 +1085,7 @@ to detect slow tests (0.3s by default) and highlight the slowest ones (1s by def
 
 Allows to pass a list of **Unix shell-style wildcards** for files to be excluded by `CompressStaticFilesStorage <#openwisp_utilsstorageCompressStaticFilesStorage>`_.
 
-By default Leaflet PNGs have been excluded to avoid bugs like `openwisp/ansible-openwisp2#232 <https://github.com/openwisp/ansible-openwisp2/issues/232>`_
+By default Leaflet PNGs have been excluded to avoid bugs like `openwisp/ansible-openwisp2#232 <https://github.com/openwisp/ansible-openwisp2/issues/232>`_.
 
 Example usage:
 

--- a/README.rst
+++ b/README.rst
@@ -1085,14 +1085,12 @@ to detect slow tests (0.3s by default) and highlight the slowest ones (1s by def
 
 Allows to pass a list of **Unix shell-style wildcards** for files to be excluded by `CompressStaticFilesStorage <#openwisp_utilsstorageCompressStaticFilesStorage>`_.
 
-Use Unix shell-style wildcards.
-
 Example usage:
 
 .. code-block:: python
 
     OPENWISP_STATICFILES_VERSIONED_EXCLUDE = [
-    '*png',
+        '*png',
     ]
 
 Installing for development

--- a/openwisp_utils/storage.py
+++ b/openwisp_utils/storage.py
@@ -1,0 +1,33 @@
+import fnmatch
+
+from compress_staticfiles.storage import (
+    CompressStaticFilesStorage as BaseCompressStaticFilesStorage,
+)
+from django.conf import settings
+
+
+class FileHashedNameMixin:
+    default_excluded_patterns = ['*.png']
+    excluded_patterns = default_excluded_patterns + getattr(
+        settings, "OPENWISP_STATICFILES_VERSIONED_EXCLUDE", []
+    )
+
+    def hashed_name(self, name, content=None, filename=None):
+        if not any(
+            fnmatch.fnmatch(name, pattern) for pattern in self.excluded_patterns
+        ):
+            return super().hashed_name(name, content, filename)
+        return name
+
+
+class CompressStaticFilesStorage(
+    FileHashedNameMixin, BaseCompressStaticFilesStorage,
+):
+    """
+    A static files storage backend for compression that inherits from
+    django-compress-staticfiles's CompressStaticFilesStorage class;
+    also adds support for excluding file types using
+    "OPENWISP_STATICFILES_VERSIONED_EXCLUDE" setting.
+    """
+
+    pass

--- a/openwisp_utils/storage.py
+++ b/openwisp_utils/storage.py
@@ -7,10 +7,7 @@ from django.conf import settings
 
 
 class FileHashedNameMixin:
-    default_excluded_patterns = ['*.png']
-    excluded_patterns = default_excluded_patterns + getattr(
-        settings, "OPENWISP_STATICFILES_VERSIONED_EXCLUDE", []
-    )
+    excluded_patterns = getattr(settings, "OPENWISP_STATICFILES_VERSIONED_EXCLUDE", [])
 
     def hashed_name(self, name, content=None, filename=None):
         if not any(

--- a/openwisp_utils/storage.py
+++ b/openwisp_utils/storage.py
@@ -7,7 +7,10 @@ from django.conf import settings
 
 
 class FileHashedNameMixin:
-    excluded_patterns = getattr(settings, "OPENWISP_STATICFILES_VERSIONED_EXCLUDE", [])
+    default_excluded_patterns = ['leaflet/*/*.png']
+    excluded_patterns = default_excluded_patterns + getattr(
+        settings, "OPENWISP_STATICFILES_VERSIONED_EXCLUDE", []
+    )
 
     def hashed_name(self, name, content=None, filename=None):
         if not any(

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,10 @@ setup(
     },
     scripts=['openwisp-qa-check', 'openwisp-qa-format', 'openwisp-pre-push-hook'],
     zip_safe=False,
-    install_requires=['django-model-utils>=4.0.0,<4.1.0'],
+    install_requires=[
+        'django-model-utils>=4.0.0,<4.1.0',
+        'django-compress-staticfiles~=1.0.1b',
+    ],
     extras_require={
         'qa': [
             'black<=19.10b0',

--- a/tests/test_project/tests/test_storage.py
+++ b/tests/test_project/tests/test_storage.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import tempfile
 
 from django.conf import settings
 from django.contrib.staticfiles import storage
@@ -8,34 +7,46 @@ from django.core.management import call_command
 from django.test import TestCase, override_settings
 
 
+def create_dir(*paths: str):
+    """
+    joins two or more pathname using os.path.join and creates leaf directory
+    and all the intermidiate ones according to the joined path using os.makedirs
+    """
+    joined_path = os.path.join(*paths)
+    os.makedirs(joined_path)
+    return joined_path
+
+
 @override_settings(
     STATICFILES_STORAGE='openwisp_utils.storage.CompressStaticFilesStorage',
-    STATIC_ROOT=os.path.join(settings.BASE_DIR, 'test_static_root'),
+    STATIC_ROOT=create_dir(settings.BASE_DIR, 'test_storage_dir', 'test_static_root'),
+    STATICFILES_DIRS=[
+        create_dir(settings.BASE_DIR, 'test_storage_dir', 'test_staticfiles_dir')
+    ],
     STATICFILES_FINDERS=['django.contrib.staticfiles.finders.FileSystemFinder'],
     OPENWISP_STATICFILES_VERSIONED_EXCLUDE=['*skip_this.txt'],
 )
 class TestCompressStaticFilesStorage(TestCase):
-    def setUp(self):
-        temp_dir = tempfile.mkdtemp()
-        os.makedirs(os.path.join(temp_dir, 'test'))
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        static_dir = settings.STATICFILES_DIRS[0]
 
-        self.file1 = os.path.join(temp_dir, 'test', 'skip_this.txt')
-        with open(self.file1, 'w') as f:
+        file1 = os.path.join(static_dir, 'skip_this.txt')
+        with open(file1, 'w') as f:
             f.write('this will not be hashed')
 
-        self.file2 = os.path.join(temp_dir, 'test', 'this.txt')
-        with open(self.file2, 'w') as f:
+        file2 = os.path.join(static_dir, 'this.txt')
+        with open(file2, 'w') as f:
             f.write('this will be hashed')
 
-        self.patched_settings = self.settings(STATICFILES_DIRS=[temp_dir])
-        self.patched_settings.enable()
-        self.addCleanup(shutil.rmtree, temp_dir)
-
-    def tearDown(self):
-        shutil.rmtree(settings.STATIC_ROOT)
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        shutil.rmtree(os.path.join(settings.BASE_DIR, 'test_storage_dir'))
 
     def test_hashed_name(self):
         call_command('collectstatic')
         hashed_files = storage.staticfiles_storage.hashed_files
-        self.assertEqual(hashed_files['test/skip_this.txt'], 'test/skip_this.txt')
-        self.assertNotEqual(hashed_files['test/this.txt'], 'test/this.txt')
+        self.assertEqual(hashed_files['skip_this.txt'], 'skip_this.txt')
+        self.assertNotEqual(hashed_files['this.txt'], 'this.txt')

--- a/tests/test_project/tests/test_storage.py
+++ b/tests/test_project/tests/test_storage.py
@@ -11,7 +11,7 @@ from django.test import TestCase, override_settings
 @override_settings(
     STATICFILES_STORAGE='openwisp_utils.storage.CompressStaticFilesStorage',
     STATIC_ROOT=os.path.join(settings.BASE_DIR, 'test_static_root'),
-    STATICFILES_FINDERS=['django.contrib.staticfiles.finders.FileSystemFinder',],
+    STATICFILES_FINDERS=['django.contrib.staticfiles.finders.FileSystemFinder'],
     OPENWISP_STATICFILES_VERSIONED_EXCLUDE=['*skip_this.txt'],
 )
 class TestCompressStaticFilesStorage(TestCase):

--- a/tests/test_project/tests/test_storage.py
+++ b/tests/test_project/tests/test_storage.py
@@ -4,9 +4,6 @@ import tempfile
 
 from django.conf import settings
 from django.contrib.staticfiles import storage
-from django.contrib.staticfiles.management.commands.collectstatic import (
-    Command as CollectstaticCommand,
-)
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 

--- a/tests/test_project/tests/test_storage.py
+++ b/tests/test_project/tests/test_storage.py
@@ -1,0 +1,44 @@
+import os
+import shutil
+import tempfile
+
+from django.conf import settings
+from django.contrib.staticfiles import storage
+from django.contrib.staticfiles.management.commands.collectstatic import (
+    Command as CollectstaticCommand,
+)
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+
+@override_settings(
+    STATICFILES_STORAGE='openwisp_utils.storage.CompressStaticFilesStorage',
+    STATIC_ROOT=os.path.join(settings.BASE_DIR, 'test_static_root'),
+    STATICFILES_FINDERS=['django.contrib.staticfiles.finders.FileSystemFinder',],
+    OPENWISP_STATICFILES_VERSIONED_EXCLUDE=['*skip_this.txt'],
+)
+class TestCompressStaticFilesStorage(TestCase):
+    def setUp(self):
+        temp_dir = tempfile.mkdtemp()
+        os.makedirs(os.path.join(temp_dir, 'test'))
+
+        self.file1 = os.path.join(temp_dir, 'test', 'skip_this.txt')
+        with open(self.file1, 'w') as f:
+            f.write('this will not be hashed')
+
+        self.file2 = os.path.join(temp_dir, 'test', 'this.txt')
+        with open(self.file2, 'w') as f:
+            f.write('this will be hashed')
+
+        self.patched_settings = self.settings(STATICFILES_DIRS=[temp_dir])
+        self.patched_settings.enable()
+        self.addCleanup(shutil.rmtree, temp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(settings.STATIC_ROOT)
+
+    def test_hashed_name(self):
+        call_command('collectstatic')
+        hashed_files = storage.staticfiles_storage.hashed_files
+        self.assertEqual(hashed_files['test/skip_this.txt'], 'test/skip_this.txt')
+        self.assertNotEqual(hashed_files['test/this.txt'], 'test/this.txt')

--- a/tests/test_project/tests/test_storage.py
+++ b/tests/test_project/tests/test_storage.py
@@ -8,7 +8,8 @@ from django.test import TestCase, override_settings
 
 
 def create_dir(*paths: str):
-    """
+    """Returns Joined path
+
     joins two or more pathname using os.path.join and creates leaf directory
     and all the intermidiate ones according to the joined path using os.makedirs
     """


### PR DESCRIPTION
Ported changes from  storage.py in ansible-openwisp2 to storage.py in openwisp_utils/

Added documentation and written test for `CompressStaticFilesStorage` in openwisp_utils.storage
In documentation created a separate storage utilities section and in settings added `OPENWISP_STATICFILES_VERSIONED_EXCLUDE`.

Created test_storage in tests/test_project/tests , The test creates a temporary folder and 2 text files in it and then runs collectstatic in that folder and checks whether the file hashed is correct or not and later deletes that folder.

Fixes #166 