### PR TITLE
[deps] Updated DRF to 3.12 #164

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 Changelog
 =========
 
-Version 0.7.5 [unreleased]
+Version 0.8.0 [unreleased]
 --------------------------
 
-- [deps] Updated djangorestframework to 3.12.0
+Changes
+-------
+
+- Updated Django REST Framework to 3.12.x
 
 Version 0.7.4 [2021-04-08]
 --------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Version 0.8.0 [unreleased]
 --------------------------
 
 Changes
--------
+~~~~~~~
 
 - Updated Django REST Framework to 3.12.x
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 0.7.5 [unreleased]
+--------------------------
+
+- [deps] Updated djangorestframework to 3.12.0
+
 Version 0.7.4 [2021-04-08]
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
             'coveralls~=3.0.0',  # depends on coverage as well
         ],
         'rest': [
-            'djangorestframework>=3.11,<3.12',
+            'djangorestframework~=3.12.0',
             'django-filter>=2.2.0<2.4.0',
             'drf-yasg~=1.20.0',
         ],


### PR DESCRIPTION
I have tested all of this module's with `djangorestframework~=3.12.0`:-

- [x] openwisp-controller
- [x] openwisp-network-topology
- [x] openwisp-notifications
- [x] openwisp-monitoring
- [x] openwisp-firmware-upgrader
- [ ] openwisp-radius

except `openwisp-radius` all of them are compatible, and are passing all the tests, 
it will get fixed by https://github.com/openwisp/openwisp-radius/pull/203/

Closes #164
