### PR TITLE
[ux] Menu button toggle 52px width

### DIFF
--- a/openwisp_utils/admin_theme/static/admin/css/openwisp.css
+++ b/openwisp_utils/admin_theme/static/admin/css/openwisp.css
@@ -146,14 +146,14 @@ html { overflow-x: hidden }
     padding: 0;
     background-color: #222;
     line-height: 40px !important;
-    width: 40px;
+    width: 52px;
     text-align: center;
 }
 
 #nav-activate:hover { background-color: #000 }
 #nav-activate:focus { outline: none }
 
-#user-tools { padding-right: 64px }
+#user-tools { padding-right: 76px }
 
 #main-menu {
     opacity: 0;


### PR DESCRIPTION
The width of the menu toggle button has been changed from 40 to 52px
Before:
![image](https://user-images.githubusercontent.com/7120526/116210580-49ef5080-a743-11eb-8a39-bf5bd9ab1b9a.png)
After:
![image](https://user-images.githubusercontent.com/7120526/116210604-4eb40480-a743-11eb-8b38-4c7271fcd6c7.png)

