### PR TITLE
[fix] Added workaround for minification of browsable API view

### DIFF
--- a/openwisp_utils/admin_theme/static/rest_framework/css/browsable-api.css
+++ b/openwisp_utils/admin_theme/static/rest_framework/css/browsable-api.css
@@ -2,6 +2,7 @@
     display: block;
     margin-top: -15px;
     margin-bottom: 10px;
+    white-space: nowrap;
 }
 
 .meta.nocode span {

--- a/openwisp_utils/admin_theme/static/rest_framework/css/browsable-api.css
+++ b/openwisp_utils/admin_theme/static/rest_framework/css/browsable-api.css
@@ -1,0 +1,14 @@
+.meta.nocode {
+    display: block;
+    margin-top: -15px;
+    margin-bottom: 10px;
+}
+
+.meta.nocode span {
+    margin-left: 8px;
+}
+
+.meta.nocode b::before {
+    content: "\a";
+    white-space: pre;
+}

--- a/openwisp_utils/admin_theme/templates/rest_framework/api.html
+++ b/openwisp_utils/admin_theme/templates/rest_framework/api.html
@@ -1,0 +1,7 @@
+{% extends "rest_framework/api.html" %}
+{% load static %}
+
+{% block head %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/browsable-api.css" %}" />
+{% endblock head %}


### PR DESCRIPTION
django-pipeline strips spaces from pre-formatted text on minifying HTML.
This destroys the representation of data on browsable API views.
Added a workaround to restore presentation to original form using CSS.

Related: https://github.com/openwisp/ansible-openwisp2/issues/256