### PR TITLE
[enhancement] Dashboard extra-config option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,13 +242,15 @@ but can be used to include any custom element in the dashboard.
 
     register_dashboard_template(position, config)
 
-+--------------------+-------------------------------------------------------------+
-| **Parameter**      | **Description**                                             |
-+--------------------+-------------------------------------------------------------+
-| ``position``       | (``int``) The position of the template.                     |
-+--------------------+-------------------------------------------------------------+
-| ``config``         | (``dict``) The configuration of the template.               |
-+--------------------+-------------------------------------------------------------+
++--------------------+----------------------------------------------------------------------------------+
+| **Parameter**      | **Description**                                                                  |
++--------------------+----------------------------------------------------------------------------------+
+| ``position``       | (``int``) The position of the template.                                          |
++--------------------+----------------------------------------------------------------------------------+
+| ``config``         | (``dict``) The configuration of the template.                                    |
++--------------------+----------------------------------------------------------------------------------+
+| ``extra_config``   | **optional** (``dict``) Extra configuration you want to pass to custom template. |
++--------------------+----------------------------------------------------------------------------------+
 
 Following properties can be configured for each template ``config``:
 
@@ -283,7 +285,10 @@ Code example:
               'leaflet/leaflet.extras.js',
               'monitoring/js/leaflet.fullscreen.min.js'
           )
-      }
+      },
+      extra_config={
+          'optional_variable': 'any_valid_value',
+      },
   )
 
 It is recommended to register dashboard templates from the ``ready``

--- a/openwisp_utils/admin_theme/dashboard.py
+++ b/openwisp_utils/admin_theme/dashboard.py
@@ -214,7 +214,7 @@ def get_dashboard_context(request):
         if 'js' in template_config[0]:
             js += list(template_config[0]['js'])
         if template_config[1]:
-            extra_config.update(template_config[1])
+            extra_config = template_config[1]
 
     context.update(
         {

--- a/openwisp_utils/admin_theme/dashboard.py
+++ b/openwisp_utils/admin_theme/dashboard.py
@@ -66,7 +66,7 @@ def _validate_template_config(config):
     return config
 
 
-def register_dashboard_template(position, config):
+def register_dashboard_template(position, config, extra_config=None):
     """
     Registers a dashboard template
     register_dashboard_template(int, dict)
@@ -79,14 +79,19 @@ def register_dashboard_template(position, config):
         raise ImproperlyConfigured(
             'Dashboard template config parameters should be of type `dict`.'
         )
+    if extra_config and not isinstance(extra_config, dict):
+        raise ImproperlyConfigured(
+            'Dashboard template extra_config parameters should be of type `dict`.'
+        )
+
     if position in DASHBOARD_TEMPLATES:
         raise ImproperlyConfigured(
             f'Cannot register template {config["template"]}. '
             f'Another template is already registered at position n. "{position}": '
-            f'{DASHBOARD_TEMPLATES[position]["template"]}'
+            f'{DASHBOARD_TEMPLATES[position][0]["template"]}'
         )
     validated_config = _validate_template_config(config)
-    DASHBOARD_TEMPLATES.update({position: validated_config})
+    DASHBOARD_TEMPLATES.update({position: [validated_config, extra_config]})
 
 
 def unregister_dashboard_template(path):
@@ -98,7 +103,7 @@ def unregister_dashboard_template(path):
         raise ImproperlyConfigured('Dashboard template path should be type `str`')
 
     for key, value in DASHBOARD_TEMPLATES.items():
-        if value['template'] == path:
+        if value[0]['template'] == path:
             key_to_remove = key
             break
     else:
@@ -198,15 +203,18 @@ def get_dashboard_context(request):
             value['filters'] = filters
 
     # dashboard templates
+    extra_config = {}
     templates = []
     css = []
     js = []
-    for position, template_config in DASHBOARD_TEMPLATES.items():
-        templates.append(template_config['template'])
-        if 'css' in template_config:
-            css += list(template_config['css'])
-        if 'js' in template_config:
-            js += list(template_config['js'])
+    for _, template_config in DASHBOARD_TEMPLATES.items():
+        templates.append(template_config[0]['template'])
+        if 'css' in template_config[0]:
+            css += list(template_config[0]['css'])
+        if 'js' in template_config[0]:
+            js += list(template_config[0]['js'])
+        if template_config[1]:
+            extra_config.update(template_config[1])
 
     context.update(
         {
@@ -216,4 +224,5 @@ def get_dashboard_context(request):
             'dashboard_js': js,
         }
     )
+    context.update(extra_config)
     return context

--- a/tests/test_project/apps.py
+++ b/tests/test_project/apps.py
@@ -85,4 +85,5 @@ class TestAppConfig(ApiAppConfig):
                 'css': ('dashboard-test.css',),
                 'js': ('dashboard-test.js',),
             },
+            extra_config={'test_extra_config': 'dashboard-test.config'},
         )

--- a/tests/test_project/templates/dashboard_test.html
+++ b/tests/test_project/templates/dashboard_test.html
@@ -1,2 +1,4 @@
 <div style="display:none">Testing dashboard</div>
-<div style="display:none">{{ test_extra_config }}</div>
+{% if test_extra_config %}
+    <div style="display:none">{{ test_extra_config }}</div>
+{% endif %}

--- a/tests/test_project/templates/dashboard_test.html
+++ b/tests/test_project/templates/dashboard_test.html
@@ -1,1 +1,2 @@
 <div style="display:none">Testing dashboard</div>
+<div style="display:none">{{ test_extra_config }}</div>

--- a/tests/test_project/tests/test_dashboard.py
+++ b/tests/test_project/tests/test_dashboard.py
@@ -90,7 +90,7 @@ class TestDashboardSchema(UnitTestCase):
         with self.subTest('Registering new dashboard template'):
             register_dashboard_template(-1, dashboard_element)
             self.assertIn(-1, DASHBOARD_TEMPLATES)
-            self.assertEqual(DASHBOARD_TEMPLATES[-1], dashboard_element)
+            self.assertEqual(DASHBOARD_TEMPLATES[-1][0], dashboard_element)
 
         with self.subTest('Registering a dashboard template at existing position'):
             with self.assertRaises(ImproperlyConfigured):
@@ -121,6 +121,11 @@ class TestDashboardSchema(UnitTestCase):
             with self.assertRaises(ImproperlyConfigured):
                 unregister_dashboard_template(dict())
 
+        with self.subTest('Registering with invalid extra_config'):
+            dashboard_element = {'template': 'test.html'}
+            with self.assertRaises(ImproperlyConfigured):
+                register_dashboard_template(1, dashboard_element, 'test')
+
 
 class TestAdminDashboard(AdminTestMixin, DjangoTestCase):
     def test_index_content(self):
@@ -134,6 +139,7 @@ class TestAdminDashboard(AdminTestMixin, DjangoTestCase):
         )
         self.assertContains(response, 'dashboard-test.js')
         self.assertContains(response, 'dashboard-test.css')
+        self.assertContains(response, 'dashboard-test.config')
         self.assertContains(response, 'jquery.init.js')
         self.assertContains(response, 'Operator presence in projects')
         self.assertContains(response, 'with_operator')

--- a/tests/test_project/tests/test_storage.py
+++ b/tests/test_project/tests/test_storage.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.contrib.staticfiles import storage
 from django.core.management import call_command
 from django.test import TestCase, override_settings
+from openwisp_utils.tests import capture_stdout
 
 
 def create_dir(*paths: str):
@@ -46,6 +47,7 @@ class TestCompressStaticFilesStorage(TestCase):
         super().tearDownClass()
         shutil.rmtree(os.path.join(settings.BASE_DIR, 'test_storage_dir'))
 
+    @capture_stdout()
     def test_hashed_name(self):
         call_command('collectstatic')
         hashed_files = storage.staticfiles_storage.hashed_files


### PR DESCRIPTION
#### Changes

I want to pass custom variables like 'base_url_to_monitoring' in my template, currently I can't add the same in the context.
This PR allows me to add any custom variable to the templates. 

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [x] I have written new test cases to avoid regressions. (if necessary)
- [x] I have updated the documentation. (e.g. README.rst)

Tested in https://github.com/openwisp/openwisp-monitoring/pull/304