### PR TITLE
Added stylelint unit `dpi`

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -14,7 +14,7 @@
         "except": ["first-nested"],
         "ignore": ["after-comment", "inside-block"]
       }],
-      "unit-allowed-list": ["em", "rem", "%", "s", "px", "vh", "deg"],
+      "unit-allowed-list": ["em", "rem", "%", "s", "px", "vh", "deg", "dpi"],
       "declaration-block-trailing-semicolon": "always",
       "property-no-unknown": true
     }


### PR DESCRIPTION
#### Changes

Fixing error:
```
openwisp_monitoring/device/static/monitoring/css/leaflet.fullscreen.css
 35:19  ✖  Unexpected unit "dpi"   unit-allowed-list
```

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [ ] I have manually tested the proposed changes.
- [x] I have written new test cases to avoid regressions. (if necessary)
- [x] I have updated the documentation. (e.g. README.rst)