### PR TITLE
[enhancement] Changed url to path/re_path #155

### DIFF
--- a/openwisp_utils/api/urls.py
+++ b/openwisp_utils/api/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import path, re_path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
 from openwisp_utils import settings as app_settings
@@ -17,18 +17,18 @@ if app_settings.API_DOCS:
     )
 
     urlpatterns += [
-        url(
+        re_path(
             r'^docs(?P<format>\.json|\.yaml)$',
             schema_view.without_ui(cache_timeout=0),
             name='schema-json',
         ),
-        url(
-            r'^docs/$',
+        path(
+            'docs/',
             schema_view.with_ui('swagger', cache_timeout=0),
             name='schema-swagger-ui',
         ),
-        url(
-            r'^redoc/$',
+        path(
+            'redoc/',
             schema_view.with_ui('redoc', cache_timeout=0),
             name='schema-redoc',
         ),

--- a/tests/test_project/api/urls.py
+++ b/tests/test_project/api/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(
+    re_path(
         r'^receive_project/(?P<pk>[^/\?]+)/$',
         views.receive_project,
         name='receive_project',

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,9 +1,8 @@
-from django.conf.urls import url
 from django.contrib import admin
-from django.urls import include
+from django.urls import include, path
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^api/v1/', include('openwisp_utils.api.urls')),
-    url(r'^api/v1/', include('test_project.api.urls')),
+    path('admin/', admin.site.urls),
+    path('api/v1/', include('openwisp_utils.api.urls')),
+    path('api/v1/', include('test_project.api.urls')),
 ]


### PR DESCRIPTION
#### Changes
Changed all `url()` calls to either `path()` or `re_path()`

`re_path()` was used when the use of regex was necessary.

fix #155

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [x] I have updated the documentation. (e.g. README.rst)

> #Closes #155#
