### PR TITLE
[change] Changed another group present message #227

### DIFF
--- a/openwisp_utils/admin_theme/menu.py
+++ b/openwisp_utils/admin_theme/menu.py
@@ -187,7 +187,7 @@ def register_menu_group(position, config):
             item_description = 'group'
         label = MENU[position].label
         raise ImproperlyConfigured(
-            f'An group/link with config {config} is being registered at position "{position}",\
+            f'A group/link with config {config} is being registered at position "{position}",\
                 but another {item_description} named "{label}" is already registered at the same position.'
         )
     if config.get('url'):

--- a/openwisp_utils/admin_theme/menu.py
+++ b/openwisp_utils/admin_theme/menu.py
@@ -182,8 +182,13 @@ def register_menu_group(position, config):
     if not isinstance(config, dict):
         raise ImproperlyConfigured('config should be a type of "dict"')
     if position in MENU:
+        item_description = 'link'
+        if isinstance(MENU[position], MenuGroup):
+            item_description = 'group'
+        label = MENU[position].label
         raise ImproperlyConfigured(
-            f'Another group is already registered at position "{position}"'
+            f'An group/link with config {config} is being registered at position "{position}",\
+                but another {item_description} named "{label}" is already registered at the same position.'
         )
     if config.get('url'):
         # It is a menu link


### PR DESCRIPTION
###Changes

Changed error message for "another group is already registered at position "X".

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [x] I have written new test cases to avoid regressions. (if necessary)
- [x] I have updated the documentation. (e.g. README.rst)
- [x] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [x] I have checked the links added / modified in the documentation.

closes #227