### PR TITLE
Commit message bug fix : dot after the issue #187

### DIFF
--- a/openwisp_utils/qa.py
+++ b/openwisp_utils/qa.py
@@ -122,7 +122,8 @@ def check_commit_message():
     # default issue mentions
     issues = []
     # ensure there's a blank line between short and long desc
-    if long_desc:
+    if long_desc and long_desc[-1] == '.':
+        long_desc = long_desc[:-1]
         if len(lines) > 1 and lines[1] != '':
             errors.append(
                 'please ensure there is a blank line between '

--- a/openwisp_utils/qa.py
+++ b/openwisp_utils/qa.py
@@ -122,8 +122,8 @@ def check_commit_message():
     # default issue mentions
     issues = []
     # ensure there's a blank line between short and long desc
-    if long_desc and long_desc[-1] == '.':
-        long_desc = long_desc[:-1]
+    if long_desc:
+        long_desc = long_desc.replace(/\./g,' ');
         if len(lines) > 1 and lines[1] != '':
             errors.append(
                 'please ensure there is a blank line between '


### PR DESCRIPTION
Issue : #187

#### Changes

> #Please explain changes made in your PR#

The problems like this https://github.com/openwisp/openwisp-controller/runs/2529479318 when placing a fullstop at the end of long description, is fixed. 

#### Checklist

- [ ] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [ ] I have manually tested the proposed changes.
- [ ] I have written new test cases to avoid regressions. (if necessary)
- [ ] I have updated the documentation. (e.g. README.rst)
- [ ] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [ ] I have checked the links added / modified in the documentation.

> #Closes #(issue-number)#
