### PR TITLE
[qa] Fix commit message check fails #187

### DIFF
--- a/openwisp_utils/qa.py
+++ b/openwisp_utils/qa.py
@@ -241,7 +241,9 @@ def _find_issue_mentions(message):
     good_mentions = 0
     for issue_location in issue_locations:
         word = words[issue_location - 1]
-        issues.append(words[issue_location])
+        issue = words[issue_location]
+        issue = issue.replace('.', '')
+        issues.append(issue)
         # check whether issue is just being referred to
         if issue_location > 1:
             preceding_2words = '{} {}'.format(

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -125,6 +125,13 @@ class TestQa(TestCase):
                 '[fix] Fixed extensibility of openwisp-users and added sample_users test app #377\n\n'
                 'Closes #377\r\n\r\nCo-authored-by: Ajay Tripathi <ajay39in@gmail.com>',
             ],
+            [
+                'commitcheck',
+                '--quiet',
+                '--message',
+                '[feature] Allow device name to be configured as not unique #443\n\n'
+                'Unique device names can now be turned off.\n\nCloses #443.',
+            ],
         ]
         for option in options:
             with patch('argparse._sys.argv', option), self.subTest(option):


### PR DESCRIPTION
#### Changes

Fix commit message check is failing when there is a dot after issue

#### Checklist

- [ ] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [ ] I have manually tested the proposed changes.
- [ ] I have written new test cases to avoid regressions. (if necessary)
- [ ] I have updated the documentation. (e.g. README.rst)
- [ ] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [ ] I have checked the links added / modified in the documentation.

Closes #187.
