### PR TITLE
[chore] Removed cleanUp JS function from menu.js #235

### DIFF
--- a/openwisp_utils/admin_theme/static/admin/js/menu.js
+++ b/openwisp_utils/admin_theme/static/admin/js/menu.js
@@ -20,16 +20,7 @@ var wasActiveGroupOpen = false;
   initToolTipHandlers();
   initResizeScreenHelpers();
   showActiveItems();
-  cleanUp();
 })();
-
-function cleanUp(){
-  // remove dublicate of objects-tools
-  var dublicateObject = document.querySelector('#content-main .object-tools');
-  if(dublicateObject){
-    dublicateObject.remove();
-  }
-}
 
 function Window() {
   /*


### PR DESCRIPTION
Closes #235

#### Changes

Removed the cleanUp JS function which removed duplicated objects.

The duplicated objects are not showing up anymore in my env, but we need to double check whether they show up in other configurations and if they do, we need to understand the reason and fix the root cause.

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [ ] I have written new test cases to avoid regressions. (if necessary)
- [ ] I have updated the documentation. (e.g. README.rst)
- [ ] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [ ] I have checked the links added / modified in the documentation.

> #Closes #(issue-number)#

Closes #235.