### PR TITLE
[deps] Updated tests requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 # For testing Dependency loaders
-openwisp_controller~=0.8.0
+openwisp_controller @ https://github.com/openwisp/openwisp-controller/tarball/master
 selenium~=3.141.0


### PR DESCRIPTION
Updated test project to use latest version of openwisp-controller. 
Otherwise, netjsonconfig was installing Jinja2 2.x which is incompatible for newer version of MarkupSafe. 