### PR TITLE
[fix] Fix dashboard details

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -351,38 +351,38 @@ and optionally, how the returned values have to be colored and labeled.
 
 Following properties can be configured for each chart ``config``:
 
-+-----------------+------------------------------------------------------------------------------------------------------+
-| **Property**    | **Description**                                                                                      |
-+-----------------+------------------------------------------------------------------------------------------------------+
-| ``query_param`` | It is a required property in form of ``dict`` containing following properties:                       |
-|                 |                                                                                                      |
-|                 | +---------------+---------------------------------------------------------------------------------+  |
-|                 | | **Property**  | **Description**                                                                 |  |
-|                 | +---------------+---------------------------------------------------------------------------------+  |
-|                 | | ``name``      | (``str``) Chart title shown in the user interface.                              |  |
-|                 | +---------------+---------------------------------------------------------------------------------+  |
-|                 | | ``app_label`` | (``str``) App label of the model that will be used to query the database.       |  |
-|                 | +---------------+---------------------------------------------------------------------------------+  |
-|                 | | ``model``     | (``str``) Name of the model that will be used to query the database.            |  |
-|                 | +---------------+---------------------------------------------------------------------------------+  |
-|                 | | ``group_by``  | (``str``) The property which will be used to group values.                      |  |
-|                 | +---------------+---------------------------------------------------------------------------------+  |
-|                 | | ``annotate``  | Alternative to ``group_by``, ``dict`` used for more complex queries.            |  |
-|                 | +---------------+---------------------------------------------------------------------------------+  |
-|                 | | ``aggregate`` | Alternative to ``group_by``, ``dict`` used for more complex queries.            |  |
-|                 | +---------------+---------------------------------------------------------------------------------+  |
-+-----------------+------------------------------------------------------------------------------------------------------+
-| ``colors``      | An **optional** ``dict`` which can be used to define colors for each distinct                        |
-|                 | value shown in the pie charts.                                                                       |
-+-----------------+------------------------------------------------------------------------------------------------------+
-| ``labels``      | An **optional** ``dict`` which can be used to define translatable strings for each distinct          |
-|                 | value shown in the pie charts. Can be used also to provide fallback human readable values for        |
-|                 | raw values stored in the database which would be otherwise hard to understand for the user.          |
-+-----------------+------------------------------------------------------------------------------------------------------+
-| ``filters``     | An **optional** ``dict`` which can be used when using ``aggregate`` and ``annotate`` in              |
-|                 | ``query_params`` to define the link that will be generated to filter results (pie charts are         |
-|                 | clickable and clicking on a portion of it will show the filtered results).                           |
-+-----------------+------------------------------------------------------------------------------------------------------+
++------------------+--------------------------------------------------------------------------------------------------------+
+| **Property**     | **Description**                                                                                        |
++------------------+--------------------------------------------------------------------------------------------------------+
+| ``query_params`` | It is a required property in form of ``dict`` containing following properties:                         |
+|                  |                                                                                                        |
+|                  | +-----------------+---------------------------------------------------------------------------------+  |
+|                  | | **Property**    | **Description**                                                                 |  |
+|                  | +-----------------+---------------------------------------------------------------------------------+  |
+|                  | | ``name``        | (``str``) Chart title shown in the user interface.                              |  |
+|                  | +-----------------+---------------------------------------------------------------------------------+  |
+|                  | | ``app_label``   | (``str``) App label of the model that will be used to query the database.       |  |
+|                  | +-----------------+---------------------------------------------------------------------------------+  |
+|                  | | ``model``       | (``str``) Name of the model that will be used to query the database.            |  |
+|                  | +-----------------+---------------------------------------------------------------------------------+  |
+|                  | | ``group_by``    | (``str``) The property which will be used to group values.                      |  |
+|                  | +-----------------+---------------------------------------------------------------------------------+  |
+|                  | | ``annotate``    | Alternative to ``group_by``, ``dict`` used for more complex queries.            |  |
+|                  | +-----------------+---------------------------------------------------------------------------------+  |
+|                  | | ``aggregate``   | Alternative to ``group_by``, ``dict`` used for more complex queries.            |  |
+|                  | +-----------------+---------------------------------------------------------------------------------+  |
++------------------+--------------------------------------------------------------------------------------------------------+
+| ``colors``       | An **optional** ``dict`` which can be used to define colors for each distinct                          |
+|                  | value shown in the pie charts.                                                                         |
++------------------+--------------------------------------------------------------------------------------------------------+
+| ``labels``       | An **optional** ``dict`` which can be used to define translatable strings for each distinct            |
+|                  | value shown in the pie charts. Can be used also to provide fallback human readable values for          |
+|                  | raw values stored in the database which would be otherwise hard to understand for the user.            |
++------------------+--------------------------------------------------------------------------------------------------------+
+| ``filters``      | An **optional** ``dict`` which can be used when using ``aggregate`` and ``annotate`` in                |
+|                  | ``query_params`` to define the link that will be generated to filter results (pie charts are           |
+|                  | clickable and clicking on a portion of it will show the filtered results).                             |
++------------------+--------------------------------------------------------------------------------------------------------+
 
 Code example:
 

--- a/openwisp_utils/admin_theme/dashboard.py
+++ b/openwisp_utils/admin_theme/dashboard.py
@@ -184,7 +184,9 @@ def get_dashboard_context(request):
                 if value.get('colors') and qs_key in value['colors']:
                     colors.append(value['colors'][qs_key])
                 values.append(obj['count'])
-            value['target_link'] = f'/admin/{app_label}/{model_name}/?{group_by}='
+            value[
+                'target_link'
+            ] = f'/admin/{app_label}/{model_name}/?{group_by}__exact='
 
         if aggregate:
             for qs_key, qs_value in qs.items():

--- a/tests/test_project/tests/test_dashboard.py
+++ b/tests/test_project/tests/test_dashboard.py
@@ -144,6 +144,7 @@ class TestAdminDashboard(AdminTestMixin, DjangoTestCase):
         self.assertContains(response, 'Operator presence in projects')
         self.assertContains(response, 'with_operator')
         self.assertContains(response, 'without_operator')
+        self.assertContains(response, 'project__name__exact')
 
         with self.subTest('Test no data'):
             Project.objects.all().delete()


### PR DESCRIPTION
#### Changes

Added __exact to the target_link of group_by dashboard
elements, this allows to show the filters in the
target page pre-selected with the chosen value, eg:

When clicking on the applied config status,
not only the page shows all the devices which have
their config applied but also shows the
Configuration Status filter with the "applied"
value already pre-selected (which was not happening
before this change).

#### Checklist


- [x] I have manually tested the proposed changes.
- [x] I have written new test cases to avoid regressions. (if necessary)
- [x] I have updated the documentation. (e.g. README.rst)