### PR TITLE
[enhancement] Improved the dashboard chart quick link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -395,6 +395,8 @@ Following properties can be configured for each chart ``config``:
 |                  | +------------------------+--------------------------------------------------------------------------+  |
 |                  | | ``label``              | (``str``) Label shown on the button                                      |  |
 |                  | +------------------------+--------------------------------------------------------------------------+  |
+|                  | | ``title``              | (``str``) Title attribute of the button element                          |  |
+|                  | +------------------------+--------------------------------------------------------------------------+  |
 |                  | | ``custom_css_classes`` | (``list``) List of CSS classes that'll be applied on the button          |  |
 |                  | +------------------------+--------------------------------------------------------------------------+  |
 +------------------+--------------------------------------------------------------------------------------------------------+
@@ -415,6 +417,12 @@ Code example:
                 'group_by': 'project__name',
             },
             'colors': {'Utils': 'red', 'User': 'orange'},
+            'quick_link': {
+                'url': '/admin/test_project/operator',
+                'label': 'Open Operators list',
+                'title': 'View complete list of operators',
+                'custom_css_classes': ['negative-top-20'],
+            },
         },
     )
 

--- a/openwisp_utils/admin_theme/static/admin/js/ow-dashboard.js
+++ b/openwisp_utils/admin_theme/static/admin/js/ow-dashboard.js
@@ -113,6 +113,7 @@
       let quickLink = document.createElement('a');
       quickLink.href = elementsParam[i].quick_link.url;
       quickLink.innerHTML = elementsParam[i].quick_link.label;
+      quickLink.title = elementsParam[i].quick_link.title || elementsParam[i].quick_link.label;
       quickLink.classList.add('button', 'quick-link');
       // Add custom css classes
       if (elementsParam[i].quick_link.custom_css_classes) {

--- a/tests/test_project/apps.py
+++ b/tests/test_project/apps.py
@@ -48,6 +48,7 @@ class TestAppConfig(ApiAppConfig):
                 'quick_link': {
                     'url': reverse_lazy('admin:test_project_operator_changelist'),
                     'label': 'Open Operators list',
+                    'title': 'View complete list of operators',
                     'custom_css_classes': ['negative-top-20'],
                 },
             },

--- a/tests/test_project/tests/test_dashboard.py
+++ b/tests/test_project/tests/test_dashboard.py
@@ -162,8 +162,9 @@ class TestAdminDashboard(AdminTestMixin, DjangoTestCase):
             response,
             (
                 '\'quick_link\': {\'url\': \'/admin/test_project/operator/\','
-                ' \'label\': \'Open Operators list\', \'custom_css_classes\': '
-                '[\'negative-top-20\']'
+                ' \'label\': \'Open Operators list\', \'title\':'
+                ' \'View complete list of operators\', \'custom_css_classes\':'
+                ' [\'negative-top-20\']'
             ),
         )
         self.assertContains(


### PR DESCRIPTION
Added "title" field to the quick_link configuration. The "title" is
used to set the "title" attribute of the quick link button.
