### PR TITLE
[change] Allowed passing extra arguments to django send_email function #311

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1129,24 +1129,28 @@ setting `OPENWISP_HTML_EMAIL <#openwisp_html_email>`_ to ``False``.
 
 .. code-block:: python
 
-    send_email(subject, body_text, body_html, recipients)
+    send_email(subject, body_text, body_html, recipients, **kwargs)
 
-+--------------------+------------------------------------------------------------------------+
-| **Parameter**      | **Description**                                                        |
-+--------------------+------------------------------------------------------------------------+
-| ``subject``        | (``str``) The subject of the email template.                           |
-+--------------------+------------------------------------------------------------------------+
-| ``body_text``      | (``str``) The body of the text message to be emailed.                  |
-+--------------------+------------------------------------------------------------------------+
-| ``body_html``      | (``str``) The body of the html template to be emailed.                 |
-+--------------------+------------------------------------------------------------------------+
-| ``recipients``     | (``list``) The list of recipients to send the mail to.                 |
-+--------------------+------------------------------------------------------------------------+
-| ``extra_context``  | **optional** (``dict``) Extra context which is passed to the template. |
-|                    | The dictionary keys ``call_to_action_text`` and ``call_to_action_url`` |
-|                    | can be passed to show a call to action button.                         |
-|                    | Similarly, ``footer`` can be passed to add a footer.                   |
-+--------------------+------------------------------------------------------------------------+
++--------------------+--------------------------------------------------------------------------------------------+
+| **Parameter**      | **Description**                                                                            |
++--------------------+--------------------------------------------------------------------------------------------+
+| ``subject``        | (``str``) The subject of the email template.                                               |
++--------------------+--------------------------------------------------------------------------------------------+
+| ``body_text``      | (``str``) The body of the text message to be emailed.                                      |
++--------------------+--------------------------------------------------------------------------------------------+
+| ``body_html``      | (``str``) The body of the html template to be emailed.                                     |
++--------------------+--------------------------------------------------------------------------------------------+
+| ``recipients``     | (``list``) The list of recipients to send the mail to.                                     |
++--------------------+--------------------------------------------------------------------------------------------+
+| ``extra_context``  | **optional** (``dict``) Extra context which is passed to the template.                     |
+|                    | The dictionary keys ``call_to_action_text`` and ``call_to_action_url``                     |
+|                    | can be passed to show a call to action button.                                             |
+|                    | Similarly, ``footer`` can be passed to add a footer.                                       |
++--------------------+--------------------------------------------------------------------------------------------+
+| ``**kwargs``       | Any additional keyword arguments (e.g. ``attachments``, ``headers``, etc.)                 |
+|                    | are passed directly to the `django.core.mail.EmailMultiAlternatives                        |
+|                    | <https://docs.djangoproject.com/en/4.1/topics/email/#sending-alternative-content-types>`_. |
++--------------------+--------------------------------------------------------------------------------------------+
 
 
 **Note**: Data passed in body should be validated and user supplied data should not be sent directly to the function.

--- a/openwisp_utils/admin_theme/email.py
+++ b/openwisp_utils/admin_theme/email.py
@@ -11,13 +11,14 @@ from . import settings as app_settings
 logger = logging.getLogger(__name__)
 
 
-def send_email(subject, body_text, body_html, recipients, extra_context={}):
+def send_email(subject, body_text, body_html, recipients, extra_context={}, **kwargs):
 
     mail = EmailMultiAlternatives(
         subject=subject,
         body=strip_tags(body_text),
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=recipients,
+        **kwargs,
     )
 
     if app_settings.OPENWISP_HTML_EMAIL and body_html:

--- a/tests/test_project/tests/test_email.py
+++ b/tests/test_project/tests/test_email.py
@@ -1,3 +1,4 @@
+from email.mime.text import MIMEText
 from unittest.mock import patch
 
 from django.core import mail
@@ -9,11 +10,13 @@ from openwisp_utils.admin_theme.email import SMTPRecipientsRefused, send_email
 class TestEmail(TestCase):
     @override_settings(DEFAULT_FROM_EMAIL='test@openwisp.io')
     def test_email(self):
+        attachment = MIMEText('Test attachment')
         send_email(
             'Test mail',
             '',
             'This is a test email',
             ['devkapilbansal@gmail.com'],
+            attachments=[attachment],
         )
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox.pop()
@@ -27,6 +30,7 @@ class TestEmail(TestCase):
         )
         # test email doesn't contain link
         self.assertNotIn('<a href', email.alternatives[0][0])
+        self.assertEqual(email.attachments[0].get_payload(), 'Test attachment')
 
     def test_email_action_text_and_url(self):
         send_email(


### PR DESCRIPTION
Closes #311

#### Changes

 Allowed passing extra arguments to django send_email function

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [x] I have written new test cases to avoid regressions. (if necessary)
- [x] I have updated the documentation. (e.g. README.rst)
- [ ] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [x] I have checked the links added / modified in the documentation.

> #Closes #(issue-number)#
