### PR TITLE
[feature] Added "organization_field" property for dashboard chart query

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -360,55 +360,59 @@ and optionally, how the returned values have to be colored and labeled.
 
 Following properties can be configured for each chart ``config``:
 
-+------------------+--------------------------------------------------------------------------------------------------------+
-| **Property**     | **Description**                                                                                        |
-+------------------+--------------------------------------------------------------------------------------------------------+
-| ``query_params`` | It is a required property in form of ``dict`` containing following properties:                         |
-|                  |                                                                                                        |
-|                  | +-----------------+---------------------------------------------------------------------------------+  |
-|                  | | **Property**    | **Description**                                                                 |  |
-|                  | +-----------------+---------------------------------------------------------------------------------+  |
-|                  | | ``name``        | (``str``) Chart title shown in the user interface.                              |  |
-|                  | +-----------------+---------------------------------------------------------------------------------+  |
-|                  | | ``app_label``   | (``str``) App label of the model that will be used to query the database.       |  |
-|                  | +-----------------+---------------------------------------------------------------------------------+  |
-|                  | | ``model``       | (``str``) Name of the model that will be used to query the database.            |  |
-|                  | +-----------------+---------------------------------------------------------------------------------+  |
-|                  | | ``group_by``    | (``str``) The property which will be used to group values.                      |  |
-|                  | +-----------------+---------------------------------------------------------------------------------+  |
-|                  | | ``annotate``    | Alternative to ``group_by``, ``dict`` used for more complex queries.            |  |
-|                  | +-----------------+---------------------------------------------------------------------------------+  |
-|                  | | ``aggregate``   | Alternative to ``group_by``, ``dict`` used for more complex queries.            |  |
-|                  | +-----------------+---------------------------------------------------------------------------------+  |
-+------------------+--------------------------------------------------------------------------------------------------------+
-| ``colors``       | An **optional** ``dict`` which can be used to define colors for each distinct                          |
-|                  | value shown in the pie charts.                                                                         |
-+------------------+--------------------------------------------------------------------------------------------------------+
-| ``labels``       | An **optional** ``dict`` which can be used to define translatable strings for each distinct            |
-|                  | value shown in the pie charts. Can be used also to provide fallback human readable values for          |
-|                  | raw values stored in the database which would be otherwise hard to understand for the user.            |
-+------------------+--------------------------------------------------------------------------------------------------------+
-| ``filters``      | An **optional** ``dict`` which can be used when using ``aggregate`` and ``annotate`` in                |
-|                  | ``query_params`` to define the link that will be generated to filter results (pie charts are           |
-|                  | clickable and clicking on a portion of it will show the filtered results).                             |
-+------------------+--------------------------------------------------------------------------------------------------------+
-| ``quick_link``   | An **optional** ``dict`` which contains configuration for the quick link button rendered               |
-|                  | below the chart.                                                                                       |
-|                  |                                                                                                        |
-|                  | **NOTE**: The chart legend is disabled if configuration for quick link button is provided.             |
-|                  |                                                                                                        |
-|                  | +------------------------+--------------------------------------------------------------------------+  |
-|                  | | **Property**           | **Description**                                                          |  |
-|                  | +------------------------+--------------------------------------------------------------------------+  |
-|                  | | ``url``                | (``str``) URL for the anchor tag                                         |  |
-|                  | +------------------------+--------------------------------------------------------------------------+  |
-|                  | | ``label``              | (``str``) Label shown on the button                                      |  |
-|                  | +------------------------+--------------------------------------------------------------------------+  |
-|                  | | ``title``              | (``str``) Title attribute of the button element                          |  |
-|                  | +------------------------+--------------------------------------------------------------------------+  |
-|                  | | ``custom_css_classes`` | (``list``) List of CSS classes that'll be applied on the button          |  |
-|                  | +------------------------+--------------------------------------------------------------------------+  |
-+------------------+--------------------------------------------------------------------------------------------------------+
++------------------+---------------------------------------------------------------------------------------------------------+
+| **Property**     | **Description**                                                                                         |
++------------------+---------------------------------------------------------------------------------------------------------+
+| ``query_params`` | It is a required property in form of ``dict`` containing following properties:                          |
+|                  |                                                                                                         |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | **Property**           | **Description**                                                           |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``name``               | (``str``) Chart title shown in the user interface.                        |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``app_label``          | (``str``) App label of the model that will be used to query the database. |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``model``              | (``str``) Name of the model that will be used to query the database.      |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``group_by``           | (``str``) The property which will be used to group values.                |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``annotate``           | Alternative to ``group_by``, ``dict`` used for more complex queries.      |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``aggregate``          | Alternative to ``group_by``, ``dict`` used for more complex queries.      |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``organization_field`` | (``str``) If the model does not have a direct relation with the           |  |
+|                  | |                        | ``Organization`` model, then indirect relation can be specified using     |  |
+|                  | |                        | this property. E.g.: ``device__organization_id``.                         |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
++------------------+---------------------------------------------------------------------------------------------------------+
+| ``colors``       | An **optional** ``dict`` which can be used to define colors for each distinct                           |
+|                  | value shown in the pie charts.                                                                          |
++------------------+---------------------------------------------------------------------------------------------------------+
+| ``labels``       | An **optional** ``dict`` which can be used to define translatable strings for each distinct             |
+|                  | value shown in the pie charts. Can be used also to provide fallback human readable values for           |
+|                  | raw values stored in the database which would be otherwise hard to understand for the user.             |
++------------------+---------------------------------------------------------------------------------------------------------+
+| ``filters``      | An **optional** ``dict`` which can be used when using ``aggregate`` and ``annotate`` in                 |
+|                  | ``query_params`` to define the link that will be generated to filter results (pie charts are            |
+|                  | clickable and clicking on a portion of it will show the filtered results).                              |
++------------------+---------------------------------------------------------------------------------------------------------+
+| ``quick_link``   | An **optional** ``dict`` which contains configuration for the quick link button rendered                |
+|                  | below the chart.                                                                                        |
+|                  |                                                                                                         |
+|                  | **NOTE**: The chart legend is disabled if configuration for quick link button is provided.              |
+|                  |                                                                                                         |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | **Property**           | **Description**                                                           |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``url``                | (``str``) URL for the anchor tag                                          |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``label``              | (``str``) Label shown on the button                                       |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``title``              | (``str``) Title attribute of the button element                           |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
+|                  | | ``custom_css_classes`` | (``list``) List of CSS classes that'll be applied on the button           |  |
+|                  | +------------------------+---------------------------------------------------------------------------+  |
++------------------+---------------------------------------------------------------------------------------------------------+
 
 Code example:
 

--- a/openwisp_utils/admin_theme/dashboard.py
+++ b/openwisp_utils/admin_theme/dashboard.py
@@ -138,7 +138,8 @@ def get_dashboard_context(request):
         group_by = query_params.get('group_by')
         annotate = query_params.get('annotate')
         aggregate = query_params.get('aggregate')
-        org_field = query_params.get('organization_field', 'organization_id')
+        org_field = query_params.get('organization_field')
+        default_org_field = 'organization_id'
         labels_i18n = value.get('labels')
 
         try:
@@ -153,8 +154,9 @@ def get_dashboard_context(request):
 
         # Filter query according to organization of user
         if not request.user.is_superuser and (
-            'organization_field' in query_params or hasattr(model, org_field)
+            org_field or hasattr(model, default_org_field)
         ):
+            org_field = org_field or default_org_field
             qs = qs.filter(**{f'{org_field}__in': request.user.organizations_managed})
 
         annotate_kwargs = {}

--- a/openwisp_utils/admin_theme/dashboard.py
+++ b/openwisp_utils/admin_theme/dashboard.py
@@ -138,6 +138,7 @@ def get_dashboard_context(request):
         group_by = query_params.get('group_by')
         annotate = query_params.get('annotate')
         aggregate = query_params.get('aggregate')
+        org_field = query_params.get('organization_field', 'organization_id')
         labels_i18n = value.get('labels')
 
         try:
@@ -151,8 +152,10 @@ def get_dashboard_context(request):
         qs = model.objects.all()
 
         # Filter query according to organization of user
-        if hasattr(model, 'organization_id') and not request.user.is_superuser:
-            qs = qs.filter(organization_id__in=request.user.organizations_managed)
+        if not request.user.is_superuser and (
+            'organization_field' in query_params or hasattr(model, org_field)
+        ):
+            qs = qs.filter(**{f'{org_field}__in': request.user.organizations_managed})
 
         annotate_kwargs = {}
         if group_by:


### PR DESCRIPTION
#### Changes

Added "organization_field" property to "query_params" of dashboard chart. It allows specifying inderect relation with the Organization model.

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [ ] I have written new test cases to avoid regressions. (if necessary)
- [x] I have updated the documentation. (e.g. README.rst)
- [ ] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [ ] I have checked the links added / modified in the documentation.

