### PR TITLE
[chores] Upgrade drf-yasg~=1.21.0 #306

### DIFF
--- a/openwisp_utils/storage.py
+++ b/openwisp_utils/storage.py
@@ -7,20 +7,6 @@ from django.conf import settings
 
 
 class FileHashedNameMixin:
-    # Workaround for DRF-yasg: https://github.com/axnsan12/drf-yasg/issues/761.
-    # TODO: Remove this when DRF-Yasg introduces proper Django 4.0 support.
-    patterns = (
-        (
-            "*.css",
-            (
-                "(?P<matched>url\\(['\"]{0,1}\\s*(?P<url>.*?)[\"']{0,1}\\))",
-                (
-                    "(?P<matched>@import\\s*[\"']\\s*(?P<url>.*?)[\"'])",
-                    '@import url("%(url)s")',
-                ),
-            ),
-        ),
-    )
 
     default_excluded_patterns = ['leaflet/*/*.png']
     excluded_patterns = default_excluded_patterns + getattr(

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'rest': [
             'djangorestframework~=3.13.0',
             'django-filter~=22.1',  # django-filter uses CalVer
-            'drf-yasg~=1.20.0',
+            'drf-yasg~=1.21.0',
         ],
         'celery': ['celery~=5.2.3'],
     },


### PR DESCRIPTION
Removed the workaround for DRF-yasg as described in #306 .

#### Changes

> Removed the following workaround added in static file storage

[openwisp-utils/openwisp_utils/storage.py](https://github.com/openwisp/openwisp-utils/blob/afa8f7bfa7a4532aab7c1c4fa4d76e55eea635c7/openwisp_utils/storage.py#L10-L23)


#### Screenshots

> #For UI changes, please share a screenshot#

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [ ] I have written new test cases to avoid regressions. (if necessary)
- [ ] I have updated the documentation. (e.g. README.rst)
- [ ] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [ ] I have checked the links added / modified in the documentation.

> #Closes #306 #
