### PR TITLE
[fix/feature] Fix autocomplete filter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1811,6 +1811,17 @@ Sets the soft time limit for celery tasks using
 Sets the hard time limit for celery tasks using
 `OpenwispCeleryTask <#openwisp_utilstasksopenwispcelerytask>`_.
 
+``OPENWISP_AUTOCOMPLETE_FILTER_VIEW``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
++---------+-------------------------------------------------------------+
+| type    | ``str``                                                     |
++---------+-------------------------------------------------------------+
+| default | ``'openwisp_utils.admin_theme.views.AutocompleteJsonView'`` |
++---------+-------------------------------------------------------------+
+
+Dotted path to the ``AutocompleteJsonView`` used by the
+``openwisp_utils.admin_theme.filters.AutocompleteFilter``.
+
 Installing for development
 --------------------------
 

--- a/openwisp_utils/admin_theme/admin.py
+++ b/openwisp_utils/admin_theme/admin.py
@@ -3,11 +3,11 @@ import logging
 from django.conf import settings
 from django.contrib import admin
 from django.urls import path
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy
 
 from . import settings as app_settings
 from .dashboard import get_dashboard_context
-from .views import AutocompleteJsonView
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +31,11 @@ class OpenwispAdminSite(admin.AdminSite):
         return super().index(request, extra_context=context)
 
     def get_urls(self):
+        autocomplete_view = import_string(app_settings.AUTOCOMPLETE_FILTER_VIEW)
         return [
             path(
                 'ow-auto-filter/',
-                self.admin_view(AutocompleteJsonView.as_view(admin_site=self)),
+                self.admin_view(autocomplete_view.as_view(admin_site=self)),
                 name='ow-auto-filter',
             ),
         ] + super().get_urls()

--- a/openwisp_utils/admin_theme/settings.py
+++ b/openwisp_utils/admin_theme/settings.py
@@ -24,3 +24,8 @@ OPENWISP_EMAIL_LOGO = getattr(
 )
 
 OPENWISP_HTML_EMAIL = getattr(settings, 'OPENWISP_HTML_EMAIL', True)
+AUTOCOMPLETE_FILTER_VIEW = getattr(
+    settings,
+    'OPENWISP_AUTOCOMPLETE_FILTER_VIEW',
+    'openwisp_utils.admin_theme.views.AutocompleteJsonView',
+)

--- a/openwisp_utils/admin_theme/templates/admin/auto_filter.html
+++ b/openwisp_utils/admin_theme/templates/admin/auto_filter.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="auto-filter ow-filter">
+<div class="ow-filter auto-filter">
   {% include 'django-admin-autocomplete-filter/autocomplete-filter.html' %}
   <div class="auto-filter-choices"></div>
 </div>

--- a/openwisp_utils/admin_theme/views.py
+++ b/openwisp_utils/admin_theme/views.py
@@ -24,6 +24,7 @@ class AutocompleteJsonView(BaseAutocompleteJsonView):
         results = []
         if (
             getattr(self.source_field, 'null', False)
+            and not getattr(self.source_field, '_get_limit_choices_to_mocked', False)
             and not self.term
             or self.term == '-'
         ):
@@ -41,6 +42,7 @@ class AutocompleteJsonView(BaseAutocompleteJsonView):
 
     def support_reverse_relation(self):
         if not hasattr(self.source_field, 'get_limit_choices_to'):
+            self.source_field._get_limit_choices_to_mocked = True
 
             def get_choices_mock():
                 return {}

--- a/openwisp_utils/admin_theme/views.py
+++ b/openwisp_utils/admin_theme/views.py
@@ -22,7 +22,11 @@ class AutocompleteJsonView(BaseAutocompleteJsonView):
         context = self.get_context_data()
         # Add option for filtering objects with None field.
         results = []
-        if not self.term or self.term == '-':
+        if (
+            getattr(self.source_field, 'null', False)
+            and not self.term
+            or self.term == '-'
+        ):
             results += [{'id': 'null', 'text': '-'}]
         results += [
             {'id': str(obj.pk), 'text': self.display_text(obj)}

--- a/tests/test_project/admin.py
+++ b/tests/test_project/admin.py
@@ -37,6 +37,7 @@ class UserAdmin(admin.ModelAdmin):
         'is_superuser',
         'is_active',
     ]
+    search_fields = ('username',)
 
 
 @admin.register(Book)
@@ -95,6 +96,12 @@ class ReverseBookFilter(AutocompleteFilter):
     parameter_name = 'book'
 
 
+class AutoOwnerFilter(AutocompleteFilter):
+    title = _('owner')
+    field_name = 'owner'
+    parameter_name = 'owner_id'
+
+
 @admin.register(Shelf)
 class ShelfAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
     # DO NOT CHANGE: used for testing filters
@@ -102,7 +109,7 @@ class ShelfAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
         ShelfFilter,
         ['books_type', InputFilter],
         ['id', InputFilter],
-        'owner__username',
+        AutoOwnerFilter,
         'books_type',
         ReverseBookFilter,
     ]

--- a/tests/test_project/tests/test_admin.py
+++ b/tests/test_project/tests/test_admin.py
@@ -412,6 +412,7 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
 
     def test_ow_auto_filter_view(self):
         url = reverse('admin:ow-auto-filter')
+        url = f'{url}?app_label=test_project&model_name=shelf&field_name=book'
         user = User.objects.create(
             username='operator',
             password='pass',


### PR DESCRIPTION
[[fix] Fixed "None" option of AutocompleteFilter](https://github.com/openwisp/openwisp-utils/commit/1cb7e4c52b9bf379346e9b647085d1acc5cdb8cd) 

AutocompleteFilter shows "None" option only if the field is
nullable. 

----

[[feature] Added setting to make AutocompleteFilter view configurable](https://github.com/openwisp/openwisp-utils/commit/caecb465db64988bd3834168b5d14e149ff1c94a) 

Added "OPENWISP_AUTOCOMPLETE_FILTER_VIEW" project setting to allow
configuring the view.

---

**Required by**

- [ ] https://github.com/openwisp/openwisp-users/pull/331