### PR TITLE
[fix] Fixed alert icon URL in HelpTextStackedInline template

### DIFF
--- a/openwisp_utils/admin_theme/templates/admin/edit_inline/help_text_stacked.html
+++ b/openwisp_utils/admin_theme/templates/admin/edit_inline/help_text_stacked.html
@@ -27,7 +27,7 @@ to add customization.
       {% comment %} OpenWISP customization begin {% endcomment %}
       {% if inline_admin_formset.formset.help_text %}
         {% with inline_admin_formset.formset.help_text as help_text %}
-          {% with help_text.image_url|default:'/admin/img/icon-alert.svg' as icon_url %}
+          {% with help_text.image_url|default:'admin/img/icon-alert.svg' as icon_url %}
             <div class="ow-help-text">
               <img src="{% static icon_url %}">
               <p>{{ help_text.text }}


### PR DESCRIPTION
#### Changes

The default value for the help text icon included a leading "/". This resulted in "Server 500" with CompressStaticFilesStorage storage backend.

#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [ ] I have written new test cases to avoid regressions. (if necessary)
- [ ] I have updated the documentation. (e.g. README.rst)
- [ ] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [ ] I have checked the links added / modified in the documentation.

> #Closes #(issue-number)#
