### PR TITLE
[feature] Added basic support for reverse relations to AutocompleteFilter

### DIFF
--- a/openwisp_utils/admin_theme/views.py
+++ b/openwisp_utils/admin_theme/views.py
@@ -17,6 +17,7 @@ class AutocompleteJsonView(BaseAutocompleteJsonView):
         if not self.has_perm(request):
             raise PermissionDenied
 
+        self.support_reverse_relation()
         self.object_list = self.get_queryset()
         context = self.get_context_data()
         # Add option for filtering objects with None field.
@@ -33,3 +34,11 @@ class AutocompleteJsonView(BaseAutocompleteJsonView):
                 'pagination': {'more': context['page_obj'].has_next()},
             }
         )
+
+    def support_reverse_relation(self):
+        if not hasattr(self.source_field, 'get_limit_choices_to'):
+
+            def get_choices_mock():
+                return {}
+
+            self.source_field.get_limit_choices_to = get_choices_mock

--- a/tests/test_project/admin.py
+++ b/tests/test_project/admin.py
@@ -42,6 +42,7 @@ class UserAdmin(admin.ModelAdmin):
 @admin.register(Book)
 class BookAdmin(admin.ModelAdmin):
     list_filter = [AutoShelfFilter, 'name']
+    search_fields = ['name']
 
 
 @admin.register(Operator)
@@ -88,6 +89,12 @@ class ShelfFilter(SimpleInputFilter):
             return queryset.filter(name__icontains=self.value())
 
 
+class ReverseBookFilter(AutocompleteFilter):
+    title = _('Book')
+    field_name = 'book'
+    parameter_name = 'book'
+
+
 @admin.register(Shelf)
 class ShelfAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
     # DO NOT CHANGE: used for testing filters
@@ -97,5 +104,6 @@ class ShelfAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
         ['id', InputFilter],
         'owner__username',
         'books_type',
+        ReverseBookFilter,
     ]
     search_fields = ['name']

--- a/tests/test_project/tests/test_admin.py
+++ b/tests/test_project/tests/test_admin.py
@@ -364,7 +364,7 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
             self.assertLessEqual(real_count, 4)
             self.assertNotContains(response, 'id="ow-apply-filter"')
 
-        with self.subTest('Test when number of filters is greater than 4'):
+        with self.subTest('Test when number of filters is greater than 5'):
             url = reverse('admin:test_project_shelf_changelist')
             response = self.client.get(url)
             real_count = self._assert_contains(
@@ -374,7 +374,7 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
                 msg_prefix='',
                 html=False,
             )[1]
-            self.assertGreater(real_count, 4)
+            self.assertGreater(real_count, 5)
             self.assertContains(response, 'id="ow-apply-filter"')
 
     def test_simple_input_filter(self):
@@ -422,3 +422,9 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
         self.client.force_login(user)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
+
+    def test_ow_auto_filter_view_reverse_relation(self):
+        url = reverse('admin:ow-auto-filter')
+        url = f'{url}?app_label=test_project&model_name=shelf&field_name=book'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This patch adds basic support for reverse relations to `AutocompleteFilter`, I added a basic test and I did manual testing.