### PR TITLE
[fix] Fixed autocomplete filter exception on invalid input #326

### DIFF
--- a/openwisp_utils/admin_theme/filters.py
+++ b/openwisp_utils/admin_theme/filters.py
@@ -1,7 +1,8 @@
 from admin_auto_filters.filters import AutocompleteFilter as BaseAutocompleteFilter
+from django.contrib import messages
 from django.contrib.admin.filters import FieldListFilter, SimpleListFilter
 from django.contrib.admin.utils import NotRelationField, get_model_from_relation
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db.models.fields import CharField, UUIDField
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -103,3 +104,17 @@ class AutocompleteFilter(BaseAutocompleteFilter):
 
     def get_autocomplete_url(self, request, model_admin):
         return reverse('admin:ow-auto-filter')
+
+    def __init__(self, *args, **kwargs):
+        try:
+            return super().__init__(*args, **kwargs)
+        except ValidationError:
+            None
+
+    def queryset(self, request, queryset):
+        try:
+            return super().queryset(request, queryset)
+        except ValidationError as e:
+            error_msg = ' '.join(e.messages)
+            messages.error(request, error_msg)
+            return queryset

--- a/tests/test_project/tests/test_admin.py
+++ b/tests/test_project/tests/test_admin.py
@@ -429,3 +429,10 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
         url = f'{url}?app_label=test_project&model_name=shelf&field_name=book'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+    def test_ow_autocomplete_filter_uuid_exception(self):
+        url = reverse('admin:test_project_book_changelist')
+        url = f'{url}?shelf__id=invalid'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '“invalid” is not a valid UUID.')


### PR DESCRIPTION
It would be good to send this fix upstream but it seems that the package we depend on is not really active in maintaining it so let's fix it here for now and in the future we'll look for a better solution or fork the package to maintain it on our own.