### PR TITLE
[fix] Make sure to HTML escape all dashboard labels

### DIFF
--- a/tests/test_project/apps.py
+++ b/tests/test_project/apps.py
@@ -89,7 +89,9 @@ class TestAppConfig(ApiAppConfig):
                     'without_operator__sum': '#353c44',
                 },
                 'labels': {
-                    'with_operator__sum': _('Projects with operators'),
+                    # the <strong> is for testing purposes to
+                    # verify it's being HTML escaped correctly
+                    'with_operator__sum': _('<strong>Projects with operators</strong>'),
                     'without_operator__sum': _('Projects without operators'),
                 },
                 'filters': {


### PR DESCRIPTION
#### Changes

Make sure to HTML escape all dashboard labels.

#### Screenshots

![Screenshot from 2023-11-22 18-16-52](https://github.com/openwisp/openwisp-utils/assets/841044/1a32153d-a33a-428d-a79c-e5cca627190f)
![Screenshot from 2023-11-22 18-16-39](https://github.com/openwisp/openwisp-utils/assets/841044/7186cd00-2d6d-4ce6-9f04-57c304017036)


#### Checklist

- [x] I have read the [contributing guidelines](http://openwisp.io/docs/developer/contributing.html#how-to-commit-your-changes-properly).
- [x] I have manually tested the proposed changes.
- [x] I have written new test cases to avoid regressions. (if necessary)
- [ ] I have updated the documentation. (e.g. README.rst)
- [ ] I have added [change!] to commit title to indicate a backward incompatible change. (if required)
- [ ] I have checked the links added / modified in the documentation.