### PR TITLE
[deps] Bumped djangorestframework>=3.14,<3.15.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'docstrfmt~=1.8.0',
         ],
         'rest': [
-            'djangorestframework>=3.14,<3.16',
+            'djangorestframework>=3.14,<3.15.2',
             'django-filter~=23.2',  # django-filter uses CalVer
             'drf-yasg~=1.21.7',
         ],


### PR DESCRIPTION
djangorestframework>=3.15.2 dropped support for Django 3.2.