### PR TITLE
[deps] Added support for Django 5.x #439

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,29 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
         django-version:
-          - django~=3.2.0
-          - django~=4.1.0
           - django~=4.2.0
+          - django~=5.0.0
+          - django~=5.1.0
+          - django~=5.2rc0
+        exclude:
+          # Django 5.0+ requires Python >=3.10
+          - python-version: "3.9"
+            django-version: django~=5.0.0
+          - python-version: "3.9"
+            django-version: django~=5.1.0
+          - python-version: "3.9"
+            django-version: django~=5.2rc0
+          # Python 3.13 supported only in Django >=5.1.3
+          - python-version: "3.13"
+            django-version: django~=4.2.0
+          - python-version: "3.13"
+            django-version: django~=5.0.0
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/developer/other-utilities.rst
+++ b/docs/developer/other-utilities.rst
@@ -86,12 +86,19 @@ Adds support for excluding file types using
 :ref:`OPENWISP_STATICFILES_VERSIONED_EXCLUDE
 <openwisp_staticfiles_versioned_exclude>` setting.
 
-To use point ``STATICFILES_STORAGE`` to
+To use point ``STORAGES["staticfiles"]`` to
 ``openwisp_utils.storage.CompressStaticFilesStorage`` in ``settings.py``.
 
 .. code-block:: python
 
-    STATICFILES_STORAGE = "openwisp_utils.storage.CompressStaticFilesStorage"
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "openwisp_utils.storage.CompressStaticFilesStorage",
+        },
+    }
 
 Other Utilities
 ---------------

--- a/openwisp_utils/admin_theme/static/admin/css/openwisp.css
+++ b/openwisp_utils/admin_theme/static/admin/css/openwisp.css
@@ -746,7 +746,8 @@ input[type="button"]:hover,
 }
 .account-button:hover span,
 .account-button:focus span,
-.account-menu a:hover span {
+.account-menu .dropdown-clickable:hover span,
+.account-menu .dropdown-clickable:focus span {
   background: #df5d43;
 }
 .account-menu {
@@ -797,19 +798,28 @@ input[type="button"]:hover,
   display: none;
   color: #777;
 }
-#header .account-menu a {
-  color: #777;
+#header .account-menu .dropdown-clickable {
   display: flex;
-  font-weight: 700;
   padding: 0.375rem;
+  color: #777;
+  font-weight: 700;
   text-decoration: none;
   line-height: 22px;
+}
+#header .account-menu #logout-form button {
+  text-transform: inherit;
+  font-size: inherit;
+  letter-spacing: inherit;
+  outline: revert;
+  width: 100%;
 }
 #header .account-menu li:last-child {
   border-bottom: 0;
 }
 .account-menu-username:hover,
-#header .account-menu a:hover {
+#header .account-menu .dropdown-clickable:hover,
+#header .account-menu .dropdown-clickable:active,
+#header .account-menu .dropdown-clickable:focus {
   color: #df5d43;
 }
 #main-content #header {

--- a/openwisp_utils/admin_theme/static/admin/css/openwisp.css
+++ b/openwisp_utils/admin_theme/static/admin/css/openwisp.css
@@ -80,6 +80,9 @@ See https://code.djangoproject.com/ticket/33878 */
 body {
   min-width: 320px;
 }
+th {
+  font-weight: 600;
+}
 .menu-backdrop {
   position: fixed;
   height: 100vh;
@@ -154,7 +157,9 @@ a.section:visited:focus,
 .module h2,
 .module caption,
 .inline-group h2,
-fieldset.module h2 {
+fieldset.module h2,
+.selector .selector-available-title,
+.selector .selector-chosen-title {
   background: #f9f9f9;
   color: #333;
   padding: 15px;
@@ -210,8 +215,14 @@ a:focus {
 .module caption,
 .inline-group h2,
 #content-related h3,
+#main .aligned .selector-available-title label,
+#main .aligned .selector-chosen-title label,
 fieldset.module h2 {
   font-size: 16px;
+}
+#content fieldset .fieldset-heading,
+#content fieldset .inline-heading {
+  border: 0px;
 }
 #main .inline-related h3 {
   padding: 15px;
@@ -433,7 +444,8 @@ div.breadcrumbs {
 #main-content div.breadcrumbs {
   padding: 1rem 2.5rem;
 }
-#main .selector-chosen h2 {
+#main .selector-chosen h2,
+#main .aligned .selector-chosen-title {
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
 }
@@ -842,7 +854,7 @@ input[type="button"]:hover,
 #content-main .object-tools {
   display: none;
 }
-#content-main .form-row a:link {
+#content-main .form-row a:link:not(.button) {
   text-decoration: underline;
 }
 #content-main .form-row a:link:hover,
@@ -1069,6 +1081,15 @@ div.calendar-shortcuts a:hover {
 }
 
 /*********** Selector fix ***********/
+.selector-available-title label,
+.selector-chosen-title label {
+  float: unset;
+}
+#main .form-row .selector-chosen-title label,
+#container #main .form-row .selector-chosen-title .helptext {
+  color: #fff;
+}
+
 @media (max-width: 1226px) and (min-width: 1024px) {
   .related-widget-wrapper > a {
     order: 2;

--- a/openwisp_utils/admin_theme/templates/admin/base_site.html
+++ b/openwisp_utils/admin_theme/templates/admin/base_site.html
@@ -38,17 +38,17 @@
       </li>
       {% if user.has_usable_password %}
       <li>
-        <a tabindex="-1" href="{% url 'admin:password_change' %}">
+        <a class="dropdown-clickable" tabindex="-1" href="{% url 'admin:password_change' %}">
           <span class="password"></span>
           {% trans 'Change password' %}
         </a>
       </li>
       {% endif %}
       <li>
-        <a tabindex="-1" class="menu-link" href="{% url 'admin:logout' %}">
-          <span class="logout"></span>
-          {% trans 'Log out' %}
-        </a>
+        <form tabindex="-1" id="logout-form" method="post" action="{% url 'admin:logout' %}">
+          {% csrf_token %}
+          <button type="submit" class="dropdown-clickable"><span class="logout"></span>{% translate 'Log out' %}</button>
+        </form>
       </li>
     </ul>
   </div>

--- a/openwisp_utils/tests/selenium.py
+++ b/openwisp_utils/tests/selenium.py
@@ -166,6 +166,11 @@ class SeleniumTestMixin:
             driver.find_element(by=By.XPATH, value='//input[@type="submit"]').click()
         self._wait_until_page_ready(driver=driver)
 
+    def logout(self, driver=None):
+        driver = driver or self.web_driver
+        self.web_driver.find_element(By.CSS_SELECTOR, '.account-button').click()
+        self.web_driver.find_element(By.CSS_SELECTOR, '#logout-form button').click()
+
     def find_element(self, by, value, timeout=2, driver=None, wait_for='visibility'):
         driver = driver or self.web_driver
         method = f'wait_for_{wait_for}'

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -50,7 +50,6 @@ ROOT_URLCONF = 'openwisp2.urls'
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 STATIC_URL = '/static/'
 

--- a/tests/test_project/tests/test_selenium.py
+++ b/tests/test_project/tests/test_selenium.py
@@ -71,7 +71,7 @@ class TestMenu(SeleniumTestMixin, StaticLiveServerTestCase):
         main_content = self._get_main_content()
         self.assertEqual(main_content.get_attribute('class'), 'm-0')
         # Test login page
-        self.web_driver.refresh()
+        self.open(reverse('admin:login'))
         self.wait_for_visibility(By.CSS_SELECTOR, self.config['site_name_css_selector'])
         hamburger = self._get_hamburger()
         logo = self._get_logo()

--- a/tests/test_project/tests/test_storage.py
+++ b/tests/test_project/tests/test_storage.py
@@ -21,7 +21,9 @@ def create_dir(*paths: str):
 
 
 @override_settings(
-    STATICFILES_STORAGE='openwisp_utils.storage.CompressStaticFilesStorage',
+    STORAGES={
+        'staticfiles': {'BACKEND': 'openwisp_utils.storage.CompressStaticFilesStorage'}
+    },
     STATIC_ROOT=create_dir(settings.BASE_DIR, 'test_storage_dir', 'test_static_root'),
     STATICFILES_DIRS=[
         create_dir(settings.BASE_DIR, 'test_storage_dir', 'test_staticfiles_dir')

--- a/tests/test_project/tests/utils.py
+++ b/tests/test_project/tests/utils.py
@@ -45,12 +45,6 @@ class SeleniumTestMixin(BaseSeleniumTestMixin, TestConfigMixin):
         opts.update(kwargs)
         return self._create_user(**opts)
 
-    def logout(self):
-        account_button = self._get_account_button()
-        account_button.click()
-        logout_link = self._get_logout_link()
-        logout_link.click()
-
     def _get_menu_toggle(self):
         return self.web_driver.find_element(By.CSS_SELECTOR, '.menu-toggle')
 

--- a/tests/test_project/tests/utils.py
+++ b/tests/test_project/tests/utils.py
@@ -115,7 +115,7 @@ class SeleniumTestMixin(BaseSeleniumTestMixin, TestConfigMixin):
         return self.web_driver.find_element(By.CSS_SELECTOR, '.account-menu-username')
 
     def _get_logout_link(self):
-        return self.web_driver.find_element(By.CSS_SELECTOR, '.menu-link')
+        return self.web_driver.find_element(By.CSS_SELECTOR, '#logout-form button')
 
     def _get_menu_backdrop(self):
         return self.web_driver.find_element(By.CSS_SELECTOR, '.menu-backdrop')


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #439

## Description of Changes

- Added support for Python 3.11, 3.12 and 3.13
- Dropped support for Django 3.2
- Dropped support for Python 3.8

**CSS changes related to changes in the Django admin:**

- Added border to the inline admin heading (I removed them in OpenWISP)
- Changed HTML elements for FilteredMultiSelect widget (widget for adding group/permission to the user)
- Added a button for resetting password of the user

---

**Blockers**
- [x] https://github.com/openwisp/django-swappable-models/pull/57