### PR TITLE
[deps] Remove coveralls in favor of coverage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
             'black~=23.12.1',
             'flake8~=7.1.0',
             'isort~=5.13.2',
-            'coverage~=7.7.1',
+            'coverage~=7.6.1',
             'tblib~=3.0.0',
             'docstrfmt~=1.8.0',
         ],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
             'black~=23.12.1',
             'flake8~=7.1.0',
             'isort~=5.13.2',
-            'coveralls~=4.0.1',  # depends on coverage as well
+            'coverage~=7.7.1',
             'tblib~=3.0.0',
             'docstrfmt~=1.8.0',
         ],


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes
The `coveralls` Python package is no longer actively maintained and is not needed locally.

Coverage reports are not uploaded to Coveralls from local builds. On CI, the `coverallsapp/github-action@v2` GitHub Action handles uploading coverage reports to coveralls.io in CI.

The coveralls package does not support Python 3.13 which is required for #452 
