### PR TITLE
[qa] Add --ignore-pattern option to exclude files from QA checks #299

### DIFF
--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -44,21 +44,41 @@ show_help() {
   printf "  --csslinter\t\t\t: Runs prettier check on css files\n"
   printf "Jslinter check options:\n"
   printf "  --jslinter\t\t\t: Runs prettier check on javascript files\n"
+  printf "Ignore pattern options:\n"
+  printf "  --ignore-pattern\t\t: Specify file patterns to ignore\n"
 }
 
 echoerr() { echo "$@" 1>&2; }
 
 runcheckendline() {
   flag=0
-  for i in $(find . -type f ! -path "*/*.egg-info/*" \
-    ! -path "./.*" \
-    ! -path "*.min.*" \
-    ! -path "*.svg" -exec grep -Iq . {} \; -and -print); do
-    if [ "$(tail -c 1 $i)" != "" ]; then
-      echo "$i needs newline at the end"
+  
+  # Start with basic exclusions
+  exclude_patterns=("*/.git/*" "*/*.egg-info/*" "*.min.*" "*.svg")
+  
+  # Add user-provided ignore pattern if specified
+  if [ -n "$IGNORE_PATTERN" ]; then
+    echo "Ignoring: $IGNORE_PATTERN"
+    exclude_patterns+=("$IGNORE_PATTERN")
+  fi
+  
+  # Build the exclusion arguments
+  exclude_args=""
+  for pattern in "${exclude_patterns[@]}"; do
+    exclude_args="$exclude_args -not -path '$pattern'"
+  done
+  
+  # Find command that uses eval to properly handle the arguments
+  find_command="find . -type f $exclude_args -exec grep -Iq . {} \; -print"
+  
+  # Run the find and process results
+  while IFS= read -r file; do
+    if [ "$(tail -c 1 "$file")" != "" ]; then
+      echo "$file needs newline at the end"
       flag=1
     fi
-  done
+  done < <(eval "$find_command")
+  
   if [ $flag -ne 0 ]; then
     echoerr "ERROR: Blank endline check failed!"
     FAILURE=1
@@ -66,7 +86,6 @@ runcheckendline() {
     echo "SUCCESS: Blank endline check successful!"
   fi
 }
-
 runcssprettiercheck() {
   package='prettier'
   if which prettier > /dev/null; then
@@ -117,11 +136,22 @@ runcheckmigrations() {
 }
 
 runflake8() {
-  flake8 && echo "SUCCESS: Flake8 check successful!" ||
-    {
-      echoerr "ERROR: Flake8 check failed!"
-      FAILURE=1
-    }
+  if [ -n "$IGNORE_PATTERN" ]; then
+
+    flake8 --exclude="$IGNORE_PATTERN" . &&
+      echo "SUCCESS: Flake8 check successful!" ||
+      {
+        echoerr "ERROR: Flake8 check failed!"
+        FAILURE=1
+      }
+  else
+    flake8 --exclude=".git,__pycache__,build,dist,*.egg-info" . &&
+      echo "SUCCESS: Flake8 check successful!" ||
+      {
+        echoerr "ERROR: Flake8 check failed!"
+        FAILURE=1
+      }
+  fi
 }
 
 runrstcheck() {
@@ -145,12 +175,24 @@ runisort() {
 }
 
 runblack() {
-  black -S --check --diff --quiet . &&
-    echo "SUCCESS: Black check successful!" ||
-    {
-      echoerr "ERROR: Black check failed! Hint: did you forget to run openwisp-qa-format?"
-      FAILURE=1
-    }
+  if [ -n "$IGNORE_PATTERN" ]; then
+    # Convert shell pattern to regex pattern for Black
+    BLACK_EXCLUDE=$(echo "$IGNORE_PATTERN" | sed 's/\./\\./g' | sed 's/\*/.*/g')
+    
+    black -S --exclude "$BLACK_EXCLUDE" --check --diff --quiet . &&
+      echo "SUCCESS: Black check successful!" ||
+      {
+        echoerr "ERROR: Black check failed! Hint: did you forget to run openwisp-qa-format?"
+        FAILURE=1
+      }
+  else
+    black --check --diff --quiet . &&
+      echo "SUCCESS: Black check successful!" ||
+      {
+        echoerr "ERROR: Black check failed! Hint: did you forget to run openwisp-qa-format?"
+        FAILURE=1
+      }
+  fi
 }
 
 runcheckcommit() {
@@ -197,11 +239,16 @@ MIGRATIONS_TO_IGNORE="0"
 COMMIT_MESSAGE=$(git log $TRAVIS_PULL_REQUEST_SHA --format=%B -n 1)
 FAILURE=0
 MODULE=""
+IGNORE_PATTERN=""
 
 while [ "$1" != "" ]; do
   case "$1" in
   --skip-checkendline)
     SKIP_CHECKENDLINE=true
+    ;;
+  --ignore-pattern)
+    shift
+    IGNORE_PATTERN="$1"
     ;;
   --skip-checkmigrations)
     SKIP_CHECKMIGRATIONS=true


### PR DESCRIPTION
- Introduced --ignore-pattern <file_pattern> option to allow users to exclude specific files or directories.
- Supports ignoring patterns like node_modules and env, which are unnecessary for QA checks.
- Ensured compatibility with existing QA check functionality.

This enhancement provides flexibility in excluding non-essential files

Fixes #299

## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #<issue-number>.

Please [open a new issue](https://github.com/openwisp/openwisp-utils/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Please describe these changes.

## Screenshot

Please include any relevant screenshots.
