### PR TITLE
[fix] Django 5.2: Updated CSS to prevent overlapping of object tools with filters

### DIFF
--- a/openwisp_utils/admin_theme/static/admin/css/openwisp.css
+++ b/openwisp_utils/admin_theme/static/admin/css/openwisp.css
@@ -877,7 +877,7 @@ input[type="button"]:hover,
 .title-wrapper h2::after {
   content: ")";
 }
-.title-wrapper .object-tools {
+#content.title-wrapper .object-tools {
   margin-top: -4px;
   margin-bottom: 20px;
 }


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

On Django 5.2, the object tools on change page were overlapping with the filters.


