### PR TITLE
[fix] Django 5.2: Updated CSS to fix styling of collapsable fieldset

### DIFF
--- a/openwisp_utils/admin_theme/static/admin/css/openwisp.css
+++ b/openwisp_utils/admin_theme/static/admin/css/openwisp.css
@@ -158,11 +158,15 @@ a.section:visited:focus,
 .module caption,
 .inline-group h2,
 fieldset.module h2,
+#content-main fieldset.module summary,
 .selector .selector-available-title,
 .selector .selector-chosen-title {
   background: #f9f9f9;
   color: #333;
   padding: 15px;
+}
+#content-main fieldset.module summary {
+  border-color: var(--hairline-color);
 }
 table thead th.sorted .sortoptions a.sortremove:focus:after,
 table thead th.sorted .sortoptions a.sortremove:hover:after,
@@ -877,7 +881,7 @@ input[type="button"]:hover,
 .title-wrapper h2::after {
   content: ")";
 }
-#content.title-wrapper .object-tools {
+#content .title-wrapper .object-tools {
   margin-top: -4px;
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

On Django 5.2, the heading for collapsable fieldset were not rendered in OpenWISP colors.

## Screenshot

This changes fixes the styling for collapsed fieldset in Django admin

![Screenshot from 2025-04-09 21-50-18](https://github.com/user-attachments/assets/141fc6ff-e6ca-4bc3-942c-b08cba9a1709)

