### PR TITLE
[fix] Fix SeleniumTestMixin to support retries with --parallel flag

### DIFF
--- a/openwisp_utils/tests/selenium.py
+++ b/openwisp_utils/tests/selenium.py
@@ -49,7 +49,9 @@ class SeleniumTestMixin:
         for attempt in range(self.retry_max + 1):
             # Use a new result object to prevent writing all attempts
             # to stdout.
-            result = self.defaultTestResult()
+            result = original_result.__class__(
+                stream=None, descriptions=None, verbosity=0
+            )
             super()._setup_and_call(result, debug)
             if result.wasSuccessful():
                 if attempt == 0:


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Previously, Selenium test cases used a `TestResult` instance to store retry results, which did not match the type of the original result object. This led to errors when using the `--parallel` flag, as Django expects a `RemoteTestResult` in parallel execution.

This fix ensures that each retry uses a new instance of the original result class, preserving compatibility with Django's test runner in both serial and parallel modes.

