### PR TITLE
[fix] Fixed the height of the logo in email template

### DIFF
--- a/openwisp_utils/admin_theme/templates/openwisp_utils/email_template.html
+++ b/openwisp_utils/admin_theme/templates/openwisp_utils/email_template.html
@@ -79,7 +79,7 @@
 
     .logo {
       width: 150px;
-      height: 86px;
+      height: auto;
     }
 
     .call-to-action {


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Bug:
Setting both heights and width would require overriding the template when the logo is customized.

Fix:
Setting the height to auto let's the logo adapt to width. If further customizations are required, then the user will need to override the email template.
