### PR TITLE
[chores] Adjusted size of pie charts to make room for geo map

### DIFF
--- a/openwisp_utils/admin_theme/static/admin/css/ow-dashboard.css
+++ b/openwisp_utils/admin_theme/static/admin/css/ow-dashboard.css
@@ -1,5 +1,5 @@
 #plot-container {
-  padding: 0.625rem 2.5rem;
+  padding: 0.25rem 2.5rem;
   text-align: center;
   overflow-x: hidden;
 }
@@ -16,7 +16,7 @@
 .js-plotly-plot .quick-link-container {
   position: absolute;
   margin-top: -30px;
-  width: 460px;
+  width: 410px;
 }
 .quick-link.button.negative-top-20 {
   position: relative;

--- a/openwisp_utils/admin_theme/static/admin/js/ow-dashboard.js
+++ b/openwisp_utils/admin_theme/static/admin/js/ow-dashboard.js
@@ -19,23 +19,24 @@
     container = document.getElementById("plot-container");
 
   const layout = {
-      height: 450,
-      width: 450,
+      height: 410,
+      width: 410,
       margin: {
         t: 0,
         b: 0,
       },
       legend: {
-        yanchor: "center",
+        yanchor: "bottom",
         xanchor: "left",
         x: 0,
-        y: 0,
+        y: -0.025,
         bgcolor: "transparent",
+        itemclick: false,
       },
       title: {
-        yanchor: "center",
-        y: 0.92,
-        font: { size: 20 },
+        yanchor: "auto",
+        y: 0.9,
+        font: { size: 18 },
       },
     },
     options = {
@@ -50,7 +51,7 @@
     delete layout.annotations;
     let data = {
         type: "pie",
-        hole: 0.6,
+        hole: 0.55,
         showlegend: !elementsParam[i].hasOwnProperty("quick_link"),
       },
       element = document.createElement("div"),
@@ -82,7 +83,7 @@
           colors: elementsParam[i].colors,
         };
       }
-      data.texttemplate = "<b>%{value}</b><br>(%{percent})";
+      data.texttemplate = "%{percent}";
       data.targetLink = elementsParam[i].target_link;
       data.filters = elementsParam[i].filters;
       data.filtering = elementsParam[i].filtering;


### PR DESCRIPTION
Related to https://github.com/openwisp/openwisp-monitoring/pull/688.

Making more room for the new features of the geographic map being worked on in GSoC-25.

<img width="1547" height="959" alt="Screenshot from 2025-09-10 18-40-33" src="https://github.com/user-attachments/assets/3d7185cf-8444-4ce9-bced-acef55d704aa" />

CC: @dee077 @pandafy.