### PR TITLE
[qa] Use in-memory DB for migration checks #186

### DIFF
--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -162,7 +162,7 @@ runcheckpendingmigrations() {
   if [ ! -f "./tests/manage.py" ]; then
     echo "File manage.py not found, skipping Make Migration Check."
   else
-    OUTPUT=$(python tests/manage.py makemigrations --dry-run $MODULE)
+    OUTPUT=$(OWQA_USE_IN_MEMORY_DB=1 python tests/manage.py makemigrations --dry-run $MODULE)
     echo $OUTPUT | grep "No changes detected" &>/dev/null &&
       echo "SUCCESS: Migrations check successful!" ||
       {

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -13,6 +13,14 @@ DATABASES = {
         "NAME": "openwisp_utils.db",
     }
 }
+
+# Force in-memory DB for QA migration checks
+if os.environ.get("OWQA_USE_IN_MEMORY_DB"):
+    DATABASES["default"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+
 if TESTING and "--exclude-tag=selenium_tests" not in sys.argv:
     DATABASES["default"]["TEST"] = {
         "NAME": os.path.join(BASE_DIR, "openwisp_utils_tests.db"),


### PR DESCRIPTION
Use an isolated SQLite in-memory database when running the `makemigrations --dry-run` QA check.

Fixes #186

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #186.

## Description of Changes

This PR updates the QA `makemigrations --dry-run` behavior to use an
isolated in-memory SQLite database instead of the default project
database. This avoids inconsistencies caused by local migration
history and ensures that migration checks run deterministically
regardless of the developer environment.

- Introduces an in-memory SQLite database for migration checking when
  `OWQA_USE_IN_MEMORY_DB` is enabled.
- Prevents migration checks from depending on user-specific DB state.
