### PR TITLE
[releaser] Fix backport insertion for RST changelog #532

### DIFF
--- a/openwisp_utils/releaser/changelog.py
+++ b/openwisp_utils/releaser/changelog.py
@@ -247,7 +247,7 @@ def update_changelog_file(changelog_path, new_block, is_port=False):
     unreleased_block_regex_str = (
         r"^(##\s+(?:Version\s+)?\S+\s+\[Unreleased\](?:.|\n)*?)(?=\n##\s+(?:Version\s+)?|\Z)"
         if is_md
-        else r"^((?:Version\s+)?\S+\s+\[Unreleased\]\n-+(?:.|\n)*?)(?=\n^(?:Version\s+)?\S|\Z)"
+        else r"^((?:Version\s+)?\S+\s+\[Unreleased\]\n-+(?:.|\n)*?)(?=\n(?:Version\s+)?\d+\.\d+\.\d+\s+\[|\Z)"
     )
     unreleased_block_regex = re.compile(
         unreleased_block_regex_str, re.IGNORECASE | re.MULTILINE

--- a/openwisp_utils/releaser/tests/test_changelog.py
+++ b/openwisp_utils/releaser/tests/test_changelog.py
@@ -280,6 +280,10 @@ def test_update_changelog_bugfix_port_flow(mock_file):
         "Version 1.2.0 [Unreleased]"
     )
     assert written_content.find("Version 1.1.3") < written_content.find("Version 1.1.2")
+    # "Work in progress." text below unreleased header should come before new bugfix block
+    assert written_content.find("Work in progress.") < written_content.find(
+        "Version 1.1.3"
+    )
 
 
 @patch("builtins.open", new_callable=mock_open, read_data=SAMPLE_CHANGELOG)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

Fix the Unreleased block regex to include content under the header (e.g., 'Work in progress.') when inserting backported bugfix changelog entries. Added a test to assert that unreleased content remains above the newly inserted block.

Fixes #532

