### PR TITLE
[change] Refactor ReceiveUrlAdmin to inherit CopyableFieldAdmin #344

### DIFF
--- a/openwisp_utils/admin.py
+++ b/openwisp_utils/admin.py
@@ -150,14 +150,14 @@ class UUIDAdmin(CopyableFieldsAdmin):
     uuid.short_description = _("UUID")
 
 
-class ReceiveUrlAdmin(ModelAdmin):
+class ReceiveUrlAdmin(CopyableFieldsAdmin):
     """Adds a receive_url field.
 
     The receive_url method will build the URL using the parameters:
 
     - receive_url_name
     - receive_url_object_arg
-    - receive_url_object_arg
+    - receive_url_querystring_arg
     """
 
     receive_url_querystring_arg = "key"
@@ -165,6 +165,7 @@ class ReceiveUrlAdmin(ModelAdmin):
     receive_url_name = None
     receive_url_urlconf = None
     receive_url_baseurl = None
+    copyable_fields = ("receive_url",)
 
     def add_view(self, request, *args, **kwargs):
         self.request = request

--- a/tests/test_project/admin.py
+++ b/tests/test_project/admin.py
@@ -8,7 +8,6 @@ from openwisp_utils.admin import (
     ReadOnlyAdmin,
     ReceiveUrlAdmin,
     TimeReadonlyAdminMixin,
-    UUIDAdmin,
 )
 from openwisp_utils.admin_theme.filters import (
     AutocompleteFilter,
@@ -80,12 +79,18 @@ class OperatorInline(HelpTextStackedInline):
 
 
 @admin.register(Project)
-class ProjectAdmin(UUIDAdmin, ReceiveUrlAdmin):
+class ProjectAdmin(ReceiveUrlAdmin):
     inlines = [OperatorInline]
     list_display = ("name",)
     fields = ("uuid", "name", "key", "receive_url")
     readonly_fields = ("uuid", "receive_url")
     receive_url_name = "receive_project"
+    copyable_fields = ("uuid", "receive_url")
+
+    def uuid(self, obj):
+        return obj.pk
+
+    uuid.short_description = _("UUID")
 
 
 class ShelfFilter(SimpleInputFilter):

--- a/tests/test_project/tests/test_admin.py
+++ b/tests/test_project/tests/test_admin.py
@@ -215,7 +215,7 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "field-uuid")
-        self.assertContains(response, "field-receive_url")
+        self.assertNotContains(response, "field-receive_url")
 
     def test_copyablefields_admin(self):
         class TestCopyableFieldAdmin(CopyableFieldsAdmin):
@@ -251,10 +251,12 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
         path = reverse("admin:test_project_project_add")
         self.client.get(path)
         ma = ProjectAdmin(Project, self.site)
-        # 'uuid' should be missing from ma.get_fields()
+        # 'uuid' and 'receive_url' should be missing from ma.get_fields()
         # because we're testing the project admin add form,
-        # and now we're adding it here again only to assert the admin field order
-        self.assertEqual(ma.fields, ("uuid", *ma.get_fields(self.client.request)))
+        # and now we're adding them here again only to assert the admin field order
+        self.assertEqual(
+            ma.fields, ("uuid", *ma.get_fields(self.client.request), "receive_url")
+        )
         self.assertEqual(
             ma.readonly_fields, ma.get_readonly_fields(self.client.request)
         )


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


Refactored ReceiveUrlAdmin to inherit from CopyableFieldsAdmin instead of ModelAdmin
Eliminated code duplication in add_view/change_view methods
Made receive_url work as a copyable field automatically
Updated ProjectAdmin to use single inheritance (no longer needs UUIDAdmin + ReceiveUrlAdmin)
Updated tests to reflect correct behavior (copyable fields excluded from add forms

Fixes #344