### PR TITLE
[change!] Remove deprecated UUIDAdmin class

### DIFF
--- a/docs/developer/admin-utilities.rst
+++ b/docs/developer/admin-utilities.rst
@@ -48,14 +48,6 @@ it easy to copy the fields contents.
 
 Useful for auto-generated fields such as UUIDs, secret keys, tokens, etc.
 
-``openwisp_utils.admin.UUIDAdmin``
-----------------------------------
-
-This class is a subclass of ``CopyableFieldsAdmin`` which sets ``uuid`` as
-the only copyable field. This class is kept for backward compatibility and
-convenience, since different models of various OpenWISP modules show
-``uuid`` as the only copyable field.
-
 ``openwisp_utils.admin.ReceiveUrlAdmin``
 ----------------------------------------
 

--- a/docs/developer/admin-utilities.rst
+++ b/docs/developer/admin-utilities.rst
@@ -48,6 +48,29 @@ it easy to copy the fields contents.
 
 Useful for auto-generated fields such as UUIDs, secret keys, tokens, etc.
 
+To replicate the "copy UUID" behavior previously provided by the removed
+``UUIDAdmin`` class, set ``copyable_fields = ("uuid",)`` on a
+``CopyableFieldsAdmin`` subclass and expose a ``uuid()`` display method,
+for example:
+
+.. code-block:: python
+
+    from django.contrib import admin
+    from django.utils.translation import gettext_lazy as _
+    from openwisp_utils.admin import CopyableFieldsAdmin
+
+    from .models import MyModel
+
+
+    @admin.register(MyModel)
+    class MyModelAdmin(CopyableFieldsAdmin):
+        copyable_fields = ("uuid",)
+
+        def uuid(self, obj):
+            return obj.pk
+
+        uuid.short_description = _("UUID")
+
 ``openwisp_utils.admin.ReceiveUrlAdmin``
 ----------------------------------------
 

--- a/openwisp_utils/admin.py
+++ b/openwisp_utils/admin.py
@@ -134,22 +134,6 @@ class CopyableFieldsAdmin(ModelAdmin):
         js = ("admin/js/jquery.init.js", "openwisp-utils/js/copyable.js")
 
 
-class UUIDAdmin(CopyableFieldsAdmin):
-    """Sets `uuid` as copyable field.
-
-    Subclass of `CopyableFieldsAdmin`. This class is kept for backward
-    compatibility and convenience, since different models of various
-    OpenWISP modules show `uuid` as the only copyable field.
-    """
-
-    copyable_fields = ("uuid",)
-
-    def uuid(self, obj):
-        return obj.pk
-
-    uuid.short_description = _("UUID")
-
-
 class ReceiveUrlAdmin(ModelAdmin):
     """Adds a receive_url field.
 

--- a/tests/test_project/admin.py
+++ b/tests/test_project/admin.py
@@ -4,11 +4,11 @@ from django.forms import ModelForm
 from django.utils.translation import gettext_lazy as _
 from openwisp_utils.admin import (
     AlwaysHasChangedMixin,
+    CopyableFieldsAdmin,
     HelpTextStackedInline,
     ReadOnlyAdmin,
     ReceiveUrlAdmin,
     TimeReadonlyAdminMixin,
-    UUIDAdmin,
 )
 from openwisp_utils.admin_theme.filters import (
     AutocompleteFilter,
@@ -80,12 +80,18 @@ class OperatorInline(HelpTextStackedInline):
 
 
 @admin.register(Project)
-class ProjectAdmin(UUIDAdmin, ReceiveUrlAdmin):
+class ProjectAdmin(CopyableFieldsAdmin, ReceiveUrlAdmin):
     inlines = [OperatorInline]
     list_display = ("name",)
     fields = ("uuid", "name", "key", "receive_url")
     readonly_fields = ("uuid", "receive_url")
     receive_url_name = "receive_project"
+    copyable_fields = ("uuid",)
+
+    def uuid(self, obj):
+        return obj.pk
+
+    uuid.short_description = _("UUID")
 
 
 class ShelfFilter(SimpleInputFilter):

--- a/tests/test_project/admin.py
+++ b/tests/test_project/admin.py
@@ -84,7 +84,7 @@ class ProjectAdmin(CopyableFieldsAdmin, ReceiveUrlAdmin):
     inlines = [OperatorInline]
     list_display = ("name",)
     fields = ("uuid", "name", "key", "receive_url")
-    readonly_fields = ("uuid", "receive_url")
+    readonly_fields = ("receive_url",)
     receive_url_name = "receive_project"
     copyable_fields = ("uuid",)
 


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.



Removed the deprecated UUIDAdmin class which was kept for backward compatibility. The CopyableFieldsAdmin class should be used instead with copyable_fields = ('uuid',) to achieve the same functionality.

- Removed UUIDAdmin class from openwisp_utils/admin.py
- Updated test ProjectAdmin to use CopyableFieldsAdmin directly
- Removed UUIDAdmin documentation from admin-utilities.rst

Closes #328
