### PR TITLE
[releaser] fixed staging untracked files #552

### DIFF
--- a/openwisp_utils/releaser/release.py
+++ b/openwisp_utils/releaser/release.py
@@ -358,8 +358,8 @@ def main():
         ["git", "checkout", "-b", release_branch], check=True, capture_output=True
     )
 
-    print("Adding all changed files to git...")
-    subprocess.run(["git", "add", "."], check=True, capture_output=True)
+    print("Adding tracked changes to git...")
+    subprocess.run(["git", "add", "-u"], check=True, capture_output=True)
 
     commit_message = f"{new_version} release"
     subprocess.run(


### PR DESCRIPTION
Replaced 'git add .' with '-u' to prevent accidental staging of untracked or sensitive files. The tool now only processes changes to files already tracked by the repository. Fixes #552

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #552 

## Description of Changes
The releaser tool was using `git add .`, which staged all files in the directory including untracked files.

I have updated the command to `git add -u`, which ensures only files already tracked by git are staged for commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release flow now stages only tracked file changes, preventing accidental inclusion of untracked files.
* **Chores**
  * Updated release log message to accurately indicate that only tracked changes are being staged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->