### PR TITLE
[chores:fix] Overrided default commitizen plugin entrypoint #110

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,5 +1,0 @@
-[tool.commitizen]
-name = "openwisp"
-version_provider = "scm"
-tag_format = "v$version"
-update_changelog_on_bump = true

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,12 @@ setup(
             "checkmigrations = openwisp_utils.qa:check_migration_name",
             "checkcommit = openwisp_utils.qa:check_commit_message",
         ],
+        # We override the default 'cz_conventional_commits' plugin to enforce the OpenWISP
+        # commit message standard across all OpenWISP repositories without requiring
+        # additional configuration in each repo. This ensures consistency and reduces
+        # maintenance overhead.
         "commitizen.plugin": [
-            "openwisp = openwisp_utils.releaser.commitizen:OpenWispCommitizen",
+            "cz_conventional_commits = openwisp_utils.releaser.commitizen:OpenWispCommitizen",
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
Changed the commitizen entry point from 'openwisp' to 'cz_conventional_commits' to make the OpenWISP commit message standard the default across all OpenWISP repositories. Dropped toml config file as not needed anymore.

Related to #110