### PR TITLE
[tests:fix] Fixed hide_loading_overlay: only wait if element is present

### DIFF
--- a/openwisp_utils/tests/selenium.py
+++ b/openwisp_utils/tests/selenium.py
@@ -285,7 +285,10 @@ class SeleniumTestMixin:
     def hide_loading_overlay(self, html_id="loading-overlay", timeout=2, driver=None):
         """The geckodriver can't figure out the loading overlay is still fading out, so let's just hide it."""
         driver = driver or self.web_driver
-        driver.execute_script(
-            f'document.getElementById("{html_id}").style.display="none";'
+        element_exists = driver.execute_script(
+            f'var el = document.getElementById("{html_id}"); '
+            f'if (el) {{ el.style.display="none"; return true; }} return false;'
         )
-        self.wait_for_invisibility(By.ID, html_id, timeout, driver)
+        # Only wait if element exists
+        if element_exists:
+            self.wait_for_invisibility(By.ID, html_id, timeout, driver)

--- a/tests/test_project/tests/test_selenium.py
+++ b/tests/test_project/tests/test_selenium.py
@@ -3,7 +3,7 @@ from unittest import expectedFailure
 from channels.testing import ChannelsLiveServerTestCase
 from django.test import tag
 from django.urls import reverse
-from selenium.common.exceptions import JavascriptException, NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 
@@ -725,13 +725,6 @@ class TestFirefoxSeleniumHelpers(SeleniumTestMixin, ChannelsLiveServerTestCase):
         self.login()
 
     def test_hide_loading_overlay(self):
-        try:
-            self.hide_loading_overlay()
-        except JavascriptException:
-            pass
-        else:
-            self.fail("Javascript exception not raised")
-
         self.web_driver.execute_script(
             'document.body.insertAdjacentHTML("beforeend", "<div id=\'loading-overlay\'></div>");'
         )


### PR DESCRIPTION
Sometimes the loading overlay may be stale/removed and this method was failing randomly causing flaky  tests.