### PR TITLE
[chores:fix] Fixed ci failure bot's ref path

### DIFF
--- a/.github/workflows/reusable-bot-ci-failure.yml
+++ b/.github/workflows/reusable-bot-ci-failure.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: openwisp/openwisp-utils
-          ref: issues/524-ci-failure-bot # will change to master upon merge
+          ref: master
           path: trusted_scripts
 
       - name: Checkout PR Code


### PR DESCRIPTION
Fixed ref path of ci failure bot from testing branch to master.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Changed ref path of reusable ci failure bot from testing branch to master.
