### PR TITLE
[chores:fix] Auto-assign bot: wait for maintainers before complaining

### DIFF
--- a/.github/actions/bot-autoassign/stale_pr_bot.py
+++ b/.github/actions/bot-autoassign/stale_pr_bot.py
@@ -1,9 +1,11 @@
 import time
-from collections import deque
 from datetime import datetime, timezone
 
 from base import GitHubBot
 from utils import unassign_linked_issues_helper
+
+# GitHub author_association values that represent project maintainers.
+MAINTAINER_ROLES = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 
 
 class StalePRBot(GitHubBot):
@@ -29,8 +31,7 @@ class StalePRBot(GitHubBot):
         if not pr_author:
             return None
         last_activity = None
-        commits = deque(pr.get_commits(), maxlen=50)
-        for commit in commits:
+        for commit in pr.get_commits():
             commit_date = commit.commit.author.date
             if commit_date > after_date:
                 if commit.author and commit.author.login == pr_author:
@@ -38,8 +39,7 @@ class StalePRBot(GitHubBot):
                         last_activity = commit_date
         if issue_comments is None:
             issue_comments = list(pr.get_issue_comments())
-        comments = issue_comments[-20:] if len(issue_comments) > 20 else issue_comments
-        for comment in comments:
+        for comment in issue_comments:
             if comment.user and comment.user.login == pr_author:
                 comment_date = comment.created_at
                 if comment_date > after_date:
@@ -47,10 +47,7 @@ class StalePRBot(GitHubBot):
                         last_activity = comment_date
         if review_comments is None:
             review_comments = list(pr.get_review_comments())
-        trimmed = (
-            review_comments[-20:] if len(review_comments) > 20 else review_comments
-        )
-        for comment in trimmed:
+        for comment in review_comments:
             if comment.user and comment.user.login == pr_author:
                 comment_date = comment.created_at
                 if comment_date > after_date:
@@ -58,8 +55,7 @@ class StalePRBot(GitHubBot):
                         last_activity = comment_date
         if all_reviews is None:
             all_reviews = list(pr.get_reviews())
-        reviews = all_reviews[-20:] if len(all_reviews) > 20 else all_reviews
-        for review in reviews:
+        for review in all_reviews:
             if review.user and review.user.login == pr_author:
                 review_date = review.submitted_at
                 if review_date and review_date > after_date:
@@ -118,39 +114,39 @@ class StalePRBot(GitHubBot):
             )
             if not last_author_activity:
                 return False
-            # Check for any non-author activity after the contributor's last action.
+            # Check for maintainer activity after the contributor's last action.
+            # Only OWNER / MEMBER / COLLABORATOR responses count; random
+            # community comments and bot messages do not.
             if issue_comments is None:
                 issue_comments = list(pr.get_issue_comments())
-            comments = (
-                issue_comments[-20:] if len(issue_comments) > 20 else issue_comments
-            )
-            for comment in comments:
+            for comment in issue_comments:
                 if (
                     comment.user
                     and comment.user.login != pr_author
                     and comment.user.type != "Bot"
+                    and getattr(comment, "author_association", None) in MAINTAINER_ROLES
                     and comment.created_at > last_author_activity
                 ):
                     return False
             if review_comments is None:
                 review_comments = list(pr.get_review_comments())
-            trimmed = (
-                review_comments[-20:] if len(review_comments) > 20 else review_comments
-            )
-            for comment in trimmed:
+            for comment in review_comments:
                 if (
                     comment.user
                     and comment.user.login != pr_author
+                    and comment.user.type != "Bot"
+                    and getattr(comment, "author_association", None) in MAINTAINER_ROLES
                     and comment.created_at > last_author_activity
                 ):
                     return False
             if all_reviews is None:
                 all_reviews = list(pr.get_reviews())
-            reviews = all_reviews[-20:] if len(all_reviews) > 20 else all_reviews
-            for review in reviews:
+            for review in all_reviews:
                 if (
                     review.user
                     and review.user.login != pr_author
+                    and review.user.type != "Bot"
+                    and getattr(review, "author_association", None) in MAINTAINER_ROLES
                     and review.submitted_at
                     and review.submitted_at > last_author_activity
                 ):
@@ -164,9 +160,8 @@ class StalePRBot(GitHubBot):
         try:
             if all_reviews is None:
                 all_reviews = list(pr.get_reviews())
-            reviews = all_reviews[-50:] if len(all_reviews) > 50 else all_reviews
             changes_requested_reviews = [
-                r for r in reviews if r.state == "CHANGES_REQUESTED"
+                r for r in all_reviews if r.state == "CHANGES_REQUESTED"
             ]
             if not changes_requested_reviews:
                 return None

--- a/.github/actions/bot-autoassign/tests/test_stale_pr_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_stale_pr_bot.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 # Add the parent directory to path for importing bot modules
@@ -139,6 +139,8 @@ class TestIsWaitingForMaintainer:
         # Maintainer reviewed after contributor's commit
         review = Mock()
         review.user.login = "maintainer"
+        review.user.type = "User"
+        review.author_association = "MEMBER"
         review.submitted_at = datetime(2024, 1, 7, tzinfo=timezone.utc)
         pr.get_reviews.return_value = [review]
         assert bot.is_waiting_for_maintainer(pr, last_cr) is False
@@ -155,6 +157,7 @@ class TestIsWaitingForMaintainer:
         comment = Mock()
         comment.user.login = "maintainer"
         comment.user.type = "User"
+        comment.author_association = "COLLABORATOR"
         comment.created_at = datetime(2024, 1, 7, tzinfo=timezone.utc)
         pr.get_issue_comments.return_value = [comment]
         assert bot.is_waiting_for_maintainer(pr, last_cr) is False
@@ -179,8 +182,48 @@ class TestIsWaitingForMaintainer:
         bot_comment = Mock()
         bot_comment.user.login = "github-actions[bot]"
         bot_comment.user.type = "Bot"
+        bot_comment.author_association = "NONE"
         bot_comment.created_at = datetime(2024, 1, 6, tzinfo=timezone.utc)
         pr.get_issue_comments.return_value = [bot_comment]
+        assert bot.is_waiting_for_maintainer(pr, last_cr) is True
+
+    def test_non_maintainer_comment_ignored(self, bot_env):
+        """A random community member commenting should not count as maintainer."""
+        bot = StalePRBot()
+        pr = self._make_pr()
+        last_cr = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        commit = Mock()
+        commit.commit.author.date = datetime(2024, 1, 5, tzinfo=timezone.utc)
+        commit.author.login = "contributor"
+        pr.get_commits.return_value = [commit]
+        comment = Mock()
+        comment.user.login = "random_user"
+        comment.user.type = "User"
+        comment.author_association = "NONE"
+        comment.created_at = datetime(2024, 1, 7, tzinfo=timezone.utc)
+        pr.get_issue_comments.return_value = [comment]
+        assert bot.is_waiting_for_maintainer(pr, last_cr) is True
+
+    def test_many_events_does_not_miss_contributor_activity(self, bot_env):
+        """Contributor activity must be found even with many subsequent events."""
+        bot = StalePRBot()
+        pr = self._make_pr()
+        last_cr = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        # Contributor pushed a commit early on
+        contributor_commit = Mock()
+        contributor_commit.commit.author.date = datetime(
+            2024, 1, 2, tzinfo=timezone.utc
+        )
+        contributor_commit.author.login = "contributor"
+        # 60 subsequent commits from CI/other (not from contributor)
+        base = datetime(2024, 1, 3, tzinfo=timezone.utc)
+        other_commits = []
+        for i in range(60):
+            c = Mock()
+            c.commit.author.date = base + timedelta(days=i)
+            c.author.login = "ci-bot"
+            other_commits.append(c)
+        pr.get_commits.return_value = [contributor_commit] + other_commits
         assert bot.is_waiting_for_maintainer(pr, last_cr) is True
 
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

This is very wrong:
https://github.com/openwisp/openwisp-utils/pull/604#issuecomment-4064456335

The bot complained with a contributor that the PR has had no activity, but no maintainer has replied since the contributor has updated his PR.

The bot shouldn't do this, it should only complain when maintainers have replied after the latest changes and there hasn't been any follow up.

I've seen a PR being closed as well recently due to the auto-assign bot, which  didn't have to be closed because there were no updates from maintainers, the PR stalled but not because of the contributor, when this happens the bot should not close anything.

This patch fixes this.