### PR TITLE
[chores] Cache CI bot dependencies #628

### DIFF
--- a/.github/actions/bot-changelog-generator/action.yml
+++ b/.github/actions/bot-changelog-generator/action.yml
@@ -15,11 +15,24 @@ inputs:
   repo-name:
     description: "Repository name in format owner/repo"
     required: true
+  cache-dependency-path:
+    description: "Path to dependency metadata used for pip cache invalidation"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
+    - name: Set up Python with cache
+      if: ${{ inputs.cache-dependency-path != '' }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+        cache: "pip"
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
     - name: Set up Python
+      if: ${{ inputs.cache-dependency-path == '' }}
       uses: actions/setup-python@v5
       with:
         python-version: "3.13"

--- a/.github/workflows/bot-autoassign-issue.yml
+++ b/.github/workflows/bot-autoassign-issue.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: pip install -e .[github_actions]

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: pip install -e .[github_actions]

--- a/.github/workflows/bot-autoassign-pr-reopen.yml
+++ b/.github/workflows/bot-autoassign-pr-reopen.yml
@@ -34,6 +34,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: pip install -e .[github_actions]
@@ -65,6 +67,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: pip install -e .[github_actions]

--- a/.github/workflows/bot-autoassign-stale-pr.yml
+++ b/.github/workflows/bot-autoassign-stale-pr.yml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
 
       - name: Install dependencies
         run: pip install -e .[github_actions]

--- a/.github/workflows/reusable-bot-autoassign.yml
+++ b/.github/workflows/reusable-bot-autoassign.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "openwisp-utils/setup.py"
 
       - name: Install dependencies
         run: pip install -e 'openwisp-utils/.[github_actions]'

--- a/.github/workflows/reusable-bot-changelog.yml
+++ b/.github/workflows/reusable-bot-changelog.yml
@@ -63,12 +63,14 @@ jobs:
           ref: master
           sparse-checkout: |
             .github/actions/bot-changelog-generator
+            setup.py
           path: openwisp-utils-action
 
       - name: Generate changelog
         if: steps.check-commits.outputs.has_noteworthy == 'true'
         uses: ./openwisp-utils-action/.github/actions/bot-changelog-generator
         with:
+          cache-dependency-path: openwisp-utils-action/setup.py
           github-token: ${{ steps.app-token.outputs.token }}
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
           pr-number: ${{ steps.check-commits.outputs.pr_number }}

--- a/.github/workflows/reusable-bot-ci-failure.yml
+++ b/.github/workflows/reusable-bot-ci-failure.yml
@@ -68,6 +68,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "trusted_scripts/setup.py"
 
       - name: Install Tools
         run: |


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #628.

## Description of Changes

- enabled pip caching for the bot workflows that install `openwisp-utils[github_actions]`, using `setup.py` as the cache invalidation key
- added cache support to the changelog composite action without changing its install command, and passed a workspace-relative dependency path from the reusable workflow
- updated the changelog workflow sparse checkout to include `setup.py` so the cache key is available there as well

Local validation:

- `git diff --check`
- `actionlint .github/workflows/*.yml`
- `act` validation covering the repo-root, nested checkout, `trusted_scripts`, sparse checkout, and composite-action caller-path shapes

## Screenshot

N/A, workflow-only change.
