### PR TITLE
[chores] Add state category color variables

### DIFF
--- a/openwisp_utils/admin_theme/static/admin/css/openwisp.css
+++ b/openwisp_utils/admin_theme/static/admin/css/openwisp.css
@@ -90,6 +90,8 @@ See https://code.djangoproject.com/ticket/33878 */
 
   /* Success/Positive */
   --ow-color-success: #498b26;
+  --ow-color-danger: #a72d1d;
+  --ow-color-warning: #ffb442;
 
   /* Foreground Scale Spectrum */
   --ow-color-black: #000;

--- a/openwisp_utils/admin_theme/static/admin/css/openwisp.css
+++ b/openwisp_utils/admin_theme/static/admin/css/openwisp.css
@@ -88,7 +88,7 @@ See https://code.djangoproject.com/ticket/33878 */
   --ow-color-primary-light: #ffe5e5;
   --ow-color-primary-lighter: #fdf2f2;
 
-  /* Success/Positive */
+  /* Status Colors */
   --ow-color-success: #498b26;
   --ow-color-danger: #a72d1d;
   --ow-color-warning: #ffb442;


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #643 

## Description of Changes
Added danger and warning variables to `openwisp.css` based on the device health state colors already used in openwisp-monitoring.