### PR TITLE
[ci] Added Selenium connection failure to transient markers

### DIFF
--- a/.github/actions/bot-ci-failure/analyze_failure.py
+++ b/.github/actions/bot-ci-failure/analyze_failure.py
@@ -31,6 +31,8 @@ TRANSIENT_FAILURE_MARKERS = (
     "Posting coverage data to https://coveralls.io",
     "OperationalError: database is locked",
     "ERROR: Could not install packages due to an OSError",
+    "selenium.common.exceptions.WebDriverException",
+    "about:neterror?e=connectionFailure",
 )
 
 

--- a/.github/actions/bot-ci-failure/analyze_failure.py
+++ b/.github/actions/bot-ci-failure/analyze_failure.py
@@ -31,7 +31,6 @@ TRANSIENT_FAILURE_MARKERS = (
     "Posting coverage data to https://coveralls.io",
     "OperationalError: database is locked",
     "ERROR: Could not install packages due to an OSError",
-    "selenium.common.exceptions.WebDriverException",
     "about:neterror?e=connectionFailure",
 )
 

--- a/.github/actions/bot-ci-failure/test_analyze_failure.py
+++ b/.github/actions/bot-ci-failure/test_analyze_failure.py
@@ -197,6 +197,13 @@ class TestIsTransientFailure(unittest.TestCase):
             )
         )
 
+    def test_detects_about_neterror_connection_failure(self):
+        self.assertTrue(
+            _is_transient_failure(
+                "Selenium loaded about:neterror?e=connectionFailure during test run"
+            )
+        )
+
     def test_normal_test_failure_not_transient(self):
         self.assertFalse(_is_transient_failure("FAIL: test_login"))
 


### PR DESCRIPTION
Added more transient failure markers that caused a skipped re-run.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Added `about:neterror?e=connectionFailure` in `TRANSIENT_FAILURE_MARKERS`.