### PR TITLE
[chores:fix] Fixed auto-assign bot claiming success on silent rejection

### DIFF
--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -3,12 +3,12 @@ import re
 import time
 
 from base import GitHubBot
-from github import GithubException
 from utils import (
     extract_linked_issues,
     find_open_pr_for_issue,
     get_valid_linked_issues,
     unassign_linked_issues_helper,
+    user_in_logins,
 )
 
 VERIFICATION_RETRY_DELAY_SECONDS = 1.0
@@ -212,42 +212,30 @@ class IssueAssignmentBot(GitHubBot):
 
     @staticmethod
     def _get_assignee_logins(issue):
-        return [
-            assignee.login
-            for assignee in getattr(issue, "assignees", []) or []
-            if hasattr(assignee, "login")
-        ]
+        return [a.login for a in issue.assignees if hasattr(a, "login")]
 
-    @staticmethod
-    def _user_in(user, logins):
-        user_lower = (user or "").lower()
-        return any(user_lower == (login or "").lower() for login in logins)
-
-    def _assignment_succeeded(self, issue_number, user):
-        # GitHub silently rejects assignment of non-collaborators who
-        # have not commented on the issue. Re-fetch to confirm, and
-        # retry once to absorb read-after-write lag. Returns None when
-        # verification itself errored — caller must stay silent.
-        attempts = 2
-        last_error = None
-        for attempt in range(attempts):
+    def _verify_assignment(self, issue_number, user):
+        """Re-fetch to confirm `user` was assigned. Returns True/False
+        on verified state, None when every fetch errored — caller
+        stays silent on None since the true state is unknown.
+        """
+        had_successful_fetch = False
+        for attempt in range(2):
             try:
                 updated_issue = self.repo.get_issue(issue_number)
-                if self._user_in(user, self._get_assignee_logins(updated_issue)):
+                had_successful_fetch = True
+                if user_in_logins(user, self._get_assignee_logins(updated_issue)):
                     return True
-            except GithubException as e:
-                last_error = e
+            except Exception as e:
                 print(
-                    f"GitHub API error verifying assignment for #{issue_number}"
-                    f" (attempt {attempt + 1}/{attempts}): {e}"
+                    f"Error verifying assignment for #{issue_number}"
+                    f" (attempt {attempt + 1}/2): {e}"
                 )
-            if attempt + 1 < attempts:
+            if attempt == 0:
                 time.sleep(VERIFICATION_RETRY_DELAY_SECONDS)
-        if last_error is not None:
-            return None
-        return False
+        return False if had_successful_fetch else None
 
-    def _build_silent_failure_message(self, pr_author, pr_number):
+    def _cannot_auto_assign_message(self, pr_author, pr_number):
         return (
             f"Hi @{pr_author} 👋,\n\n"
             f"Thank you for opening PR #{pr_number} to address this issue!\n\n"
@@ -267,8 +255,7 @@ class IssueAssignmentBot(GitHubBot):
             issue = self.repo.get_issue(issue_number)
             if (
                 hasattr(issue, "repository")
-                and getattr(issue.repository, "full_name", self.repository_name)
-                != self.repository_name
+                and issue.repository.full_name != self.repository_name
             ):
                 print(
                     f"Issue #{issue_number} is from a different"
@@ -281,21 +268,29 @@ class IssueAssignmentBot(GitHubBot):
             if getattr(issue, "state", "open") == "closed":
                 print(f"#{issue_number} is closed, ignoring bot command")
                 return True
-            if self._user_in(commenter, self._get_assignee_logins(issue)):
+            if user_in_logins(commenter, self._get_assignee_logins(issue)):
                 print(f"{commenter} is already assigned to #{issue_number}")
                 return True
-            pr = find_open_pr_for_issue(self.repo, commenter, issue_number)
+            try:
+                pr = find_open_pr_for_issue(
+                    self.github, self.repository_name, commenter, issue_number
+                )
+            except Exception as e:
+                # Don't post "no PR found" on a search error — that's
+                # not the same as a verified miss.
+                print(f"Error searching open PRs by {commenter}: {e}")
+                return True
             if pr is None:
                 issue.create_comment(
                     f"Hi @{commenter} 👋,\n\n"
                     "I could not find an open PR by you that references"
                     f" this issue (#{issue_number}). Please open a PR"
                     f" linking to this issue (e.g. `Fixes #{issue_number}`)"
-                    " and then re-run the command."
+                    f" and then comment `@{self.bot_username} assign` again."
                 )
                 return True
             issue.add_to_assignees(commenter)
-            verified = self._assignment_succeeded(issue_number, commenter)
+            verified = self._verify_assignment(issue_number, commenter)
             if verified is True:
                 issue.create_comment(
                     f"This issue has been assigned to @{commenter}"
@@ -303,6 +298,8 @@ class IssueAssignmentBot(GitHubBot):
                 )
                 print(f"Assigned #{issue_number} to {commenter} via bot command")
             elif verified is False:
+                # Commenter has commented but the assignment still
+                # failed (perm block, outage, etc.).
                 issue.create_comment(
                     f"Sorry @{commenter}, GitHub still did not allow"
                     " this assignment. A maintainer will need to assign"
@@ -310,12 +307,12 @@ class IssueAssignmentBot(GitHubBot):
                 )
                 print(
                     f"Bot-command assignment of #{issue_number} to"
-                    f" {commenter} was silently rejected"
+                    f" {commenter} was silently rejected."
                 )
             else:
                 print(
                     f"Skipping comment for #{issue_number}:"
-                    " assignment state could not be verified"
+                    " assignment state could not be verified."
                 )
             return True
         except Exception as e:
@@ -339,7 +336,7 @@ class IssueAssignmentBot(GitHubBot):
                 )
             assigned_issues = []
             for issue_number, issue in get_valid_linked_issues(
-                self.repo, self.repository_name, pr_body
+                self.repo, self.repository_name, linked_issues
             ):
                 if len(assigned_issues) >= max_issues:
                     break
@@ -352,7 +349,7 @@ class IssueAssignmentBot(GitHubBot):
                         continue
                     current_assignees = self._get_assignee_logins(issue)
                     if current_assignees:
-                        if self._user_in(pr_author, current_assignees):
+                        if user_in_logins(pr_author, current_assignees):
                             print(
                                 f"Issue #{issue_number} already"
                                 f" assigned to {pr_author}"
@@ -365,7 +362,7 @@ class IssueAssignmentBot(GitHubBot):
                             )
                         continue
                     issue.add_to_assignees(pr_author)
-                    verified = self._assignment_succeeded(issue_number, pr_author)
+                    verified = self._verify_assignment(issue_number, pr_author)
                     if verified is True:
                         assigned_issues.append(issue_number)
                         print(f"Assigned issue #{issue_number} to {pr_author}")
@@ -379,18 +376,18 @@ class IssueAssignmentBot(GitHubBot):
                     elif verified is False:
                         print(
                             f"Assignment of #{issue_number} to {pr_author}"
-                            " was silently rejected by GitHub"
+                            " was silently rejected by GitHub."
                         )
                         issue.create_comment(
-                            self._build_silent_failure_message(pr_author, pr_number)
+                            self._cannot_auto_assign_message(pr_author, pr_number)
                         )
                     else:
                         print(
                             f"Skipping comment for #{issue_number}:"
-                            " assignment state could not be verified"
+                            " assignment state could not be verified."
                         )
                 except Exception as e:
-                    print(f"Error processing issue" f" #{issue_number}: {e}")
+                    print(f"Error processing issue #{issue_number}: {e}")
             return assigned_issues
         except Exception as e:
             print(f"Error in auto_assign_issues_from_pr: {e}")

--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -1,14 +1,30 @@
+import os
 import re
+import time
 
 from base import GitHubBot
+from github import GithubException
 from utils import (
     extract_linked_issues,
+    find_open_pr_for_issue,
     get_valid_linked_issues,
     unassign_linked_issues_helper,
 )
 
+VERIFICATION_RETRY_DELAY_SECONDS = 1.0
+
 
 class IssueAssignmentBot(GitHubBot):
+    def __init__(self):
+        super().__init__()
+        self.bot_username = os.environ.get("BOT_USERNAME", "openwisp-companion")
+
+    def is_bot_assign_command(self, comment_body):
+        if not comment_body:
+            return False
+        pattern = rf"(?<![\w-])@{re.escape(self.bot_username)}\s+assign\b"
+        return bool(re.search(pattern, comment_body, re.IGNORECASE))
+
     def is_assignment_request(self, comment_body):
         if not comment_body:
             return False
@@ -194,6 +210,118 @@ class IssueAssignmentBot(GitHubBot):
             print(f"Error responding to assignment request: {e}")
             return False
 
+    @staticmethod
+    def _get_assignee_logins(issue):
+        return [
+            assignee.login
+            for assignee in getattr(issue, "assignees", []) or []
+            if hasattr(assignee, "login")
+        ]
+
+    @staticmethod
+    def _user_in(user, logins):
+        user_lower = (user or "").lower()
+        return any(user_lower == (login or "").lower() for login in logins)
+
+    def _assignment_succeeded(self, issue_number, user):
+        # GitHub silently rejects assignment of non-collaborators who
+        # have not commented on the issue. Re-fetch to confirm, and
+        # retry once to absorb read-after-write lag. Returns None when
+        # verification itself errored — caller must stay silent.
+        attempts = 2
+        last_error = None
+        for attempt in range(attempts):
+            try:
+                updated_issue = self.repo.get_issue(issue_number)
+                if self._user_in(user, self._get_assignee_logins(updated_issue)):
+                    return True
+            except GithubException as e:
+                last_error = e
+                print(
+                    f"GitHub API error verifying assignment for #{issue_number}"
+                    f" (attempt {attempt + 1}/{attempts}): {e}"
+                )
+            if attempt + 1 < attempts:
+                time.sleep(VERIFICATION_RETRY_DELAY_SECONDS)
+        if last_error is not None:
+            return None
+        return False
+
+    def _build_silent_failure_message(self, pr_author, pr_number):
+        return (
+            f"Hi @{pr_author} 👋,\n\n"
+            f"Thank you for opening PR #{pr_number} to address this issue!\n\n"
+            "GitHub did not allow the bot to assign this issue to you"
+            " automatically, because you are not yet an organization"
+            " member and have not previously commented on this issue.\n\n"
+            f"To get assigned, please comment `@{self.bot_username} assign`"
+            " on this issue. Your comment satisfies GitHub's requirement"
+            " and the bot will then assign the issue to you."
+        )
+
+    def handle_bot_assign_request(self, issue_number, commenter):
+        if not self.repo:
+            print("GitHub client not initialized")
+            return False
+        try:
+            issue = self.repo.get_issue(issue_number)
+            if (
+                hasattr(issue, "repository")
+                and getattr(issue.repository, "full_name", self.repository_name)
+                != self.repository_name
+            ):
+                print(
+                    f"Issue #{issue_number} is from a different"
+                    " repository, ignoring bot command"
+                )
+                return True
+            if issue.pull_request:
+                print(f"#{issue_number} is a PR, ignoring bot command")
+                return True
+            if getattr(issue, "state", "open") == "closed":
+                print(f"#{issue_number} is closed, ignoring bot command")
+                return True
+            if self._user_in(commenter, self._get_assignee_logins(issue)):
+                print(f"{commenter} is already assigned to #{issue_number}")
+                return True
+            pr = find_open_pr_for_issue(self.repo, commenter, issue_number)
+            if pr is None:
+                issue.create_comment(
+                    f"Hi @{commenter} 👋,\n\n"
+                    "I could not find an open PR by you that references"
+                    f" this issue (#{issue_number}). Please open a PR"
+                    f" linking to this issue (e.g. `Fixes #{issue_number}`)"
+                    " and then re-run the command."
+                )
+                return True
+            issue.add_to_assignees(commenter)
+            verified = self._assignment_succeeded(issue_number, commenter)
+            if verified is True:
+                issue.create_comment(
+                    f"This issue has been assigned to @{commenter}"
+                    f" who opened PR #{pr.number} to address it. 🎯"
+                )
+                print(f"Assigned #{issue_number} to {commenter} via bot command")
+            elif verified is False:
+                issue.create_comment(
+                    f"Sorry @{commenter}, GitHub still did not allow"
+                    " this assignment. A maintainer will need to assign"
+                    " this issue manually."
+                )
+                print(
+                    f"Bot-command assignment of #{issue_number} to"
+                    f" {commenter} was silently rejected"
+                )
+            else:
+                print(
+                    f"Skipping comment for #{issue_number}:"
+                    " assignment state could not be verified"
+                )
+            return True
+        except Exception as e:
+            print(f"Error handling bot assign command: {e}")
+            return False
+
     def auto_assign_issues_from_pr(self, pr_number, pr_author, pr_body, max_issues=10):
         if not self.repo:
             print("GitHub client not initialized")
@@ -216,13 +344,15 @@ class IssueAssignmentBot(GitHubBot):
                 if len(assigned_issues) >= max_issues:
                     break
                 try:
-                    current_assignees = [
-                        assignee.login
-                        for assignee in issue.assignees
-                        if hasattr(assignee, "login")
-                    ]
+                    if getattr(issue, "state", "open") == "closed":
+                        print(
+                            f"Issue #{issue_number} is closed, skipping"
+                            " auto-assignment"
+                        )
+                        continue
+                    current_assignees = self._get_assignee_logins(issue)
                     if current_assignees:
-                        if pr_author in current_assignees:
+                        if self._user_in(pr_author, current_assignees):
                             print(
                                 f"Issue #{issue_number} already"
                                 f" assigned to {pr_author}"
@@ -235,15 +365,30 @@ class IssueAssignmentBot(GitHubBot):
                             )
                         continue
                     issue.add_to_assignees(pr_author)
-                    assigned_issues.append(issue_number)
-                    print(f"Assigned issue #{issue_number}" f" to {pr_author}")
-                    comment_message = (
-                        "This issue has been automatically"
-                        f" assigned to @{pr_author}"
-                        f" who opened PR #{pr_number}"
-                        " to address it. 🎯"
-                    )
-                    issue.create_comment(comment_message)
+                    verified = self._assignment_succeeded(issue_number, pr_author)
+                    if verified is True:
+                        assigned_issues.append(issue_number)
+                        print(f"Assigned issue #{issue_number} to {pr_author}")
+                        comment_message = (
+                            "This issue has been automatically"
+                            f" assigned to @{pr_author}"
+                            f" who opened PR #{pr_number}"
+                            " to address it. 🎯"
+                        )
+                        issue.create_comment(comment_message)
+                    elif verified is False:
+                        print(
+                            f"Assignment of #{issue_number} to {pr_author}"
+                            " was silently rejected by GitHub"
+                        )
+                        issue.create_comment(
+                            self._build_silent_failure_message(pr_author, pr_number)
+                        )
+                    else:
+                        print(
+                            f"Skipping comment for #{issue_number}:"
+                            " assignment state could not be verified"
+                        )
                 except Exception as e:
                     print(f"Error processing issue" f" #{issue_number}: {e}")
             return assigned_issues
@@ -266,11 +411,27 @@ class IssueAssignmentBot(GitHubBot):
             print(f"Error in unassign_issues_from_pr: {e}")
             return []
 
+    def _is_bot_comment(self, comment):
+        user = comment.get("user") or {}
+        if (user.get("type") or "").lower() == "bot":
+            return True
+        if comment.get("performed_via_github_app"):
+            return True
+        login = (user.get("login") or "").lower()
+        return login in {
+            self.bot_username.lower(),
+            f"{self.bot_username}[bot]".lower(),
+        }
+
     def handle_issue_comment(self):
         if not self.event_payload:
             print("No event payload available")
             return False
         try:
+            action = self.event_payload.get("action")
+            if action and action != "created":
+                print(f"Ignoring issue_comment action '{action}'")
+                return True
             if self.event_payload.get("issue", {}).get("pull_request"):
                 print("Comment is on a PR, not an issue - skipping")
                 return True
@@ -282,9 +443,14 @@ class IssueAssignmentBot(GitHubBot):
             if not all([comment_body, commenter, issue_number]):
                 print("Missing required comment data")
                 return False
+            if self._is_bot_comment(comment):
+                print("Ignoring comment posted by a bot")
+                return True
+            if self.is_bot_assign_command(comment_body):
+                return self.handle_bot_assign_request(issue_number, commenter)
             if self.is_assignment_request(comment_body):
                 return self.respond_to_assignment_request(issue_number, commenter)
-            print("Comment does not contain assignment request")
+            print("Comment does not contain an assignment request or bot command")
             return True
         except Exception as e:
             print(f"Error handling issue comment: {e}")

--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -1,17 +1,16 @@
 import os
 import re
-import time
 
 from base import GitHubBot
 from utils import (
     extract_linked_issues,
     find_open_pr_for_issue,
+    get_assignee_logins,
     get_valid_linked_issues,
     unassign_linked_issues_helper,
     user_in_logins,
+    verify_assignment,
 )
-
-VERIFICATION_RETRY_DELAY_SECONDS = 1.0
 
 
 class IssueAssignmentBot(GitHubBot):
@@ -210,31 +209,6 @@ class IssueAssignmentBot(GitHubBot):
             print(f"Error responding to assignment request: {e}")
             return False
 
-    @staticmethod
-    def _get_assignee_logins(issue):
-        return [a.login for a in issue.assignees if hasattr(a, "login")]
-
-    def _verify_assignment(self, issue_number, user):
-        """Re-fetch to confirm `user` was assigned. Returns True/False
-        on verified state, None when every fetch errored — caller
-        stays silent on None since the true state is unknown.
-        """
-        had_successful_fetch = False
-        for attempt in range(2):
-            try:
-                updated_issue = self.repo.get_issue(issue_number)
-                had_successful_fetch = True
-                if user_in_logins(user, self._get_assignee_logins(updated_issue)):
-                    return True
-            except Exception as e:
-                print(
-                    f"Error verifying assignment for #{issue_number}"
-                    f" (attempt {attempt + 1}/2): {e}"
-                )
-            if attempt == 0:
-                time.sleep(VERIFICATION_RETRY_DELAY_SECONDS)
-        return False if had_successful_fetch else None
-
     def _cannot_auto_assign_message(self, pr_author, pr_number):
         return (
             f"Hi @{pr_author} 👋,\n\n"
@@ -268,7 +242,7 @@ class IssueAssignmentBot(GitHubBot):
             if getattr(issue, "state", "open") == "closed":
                 print(f"#{issue_number} is closed, ignoring bot command")
                 return True
-            if user_in_logins(commenter, self._get_assignee_logins(issue)):
+            if user_in_logins(commenter, get_assignee_logins(issue)):
                 print(f"{commenter} is already assigned to #{issue_number}")
                 return True
             try:
@@ -290,7 +264,7 @@ class IssueAssignmentBot(GitHubBot):
                 )
                 return True
             issue.add_to_assignees(commenter)
-            verified = self._verify_assignment(issue_number, commenter)
+            verified = verify_assignment(self.repo, issue_number, commenter)
             if verified is True:
                 issue.create_comment(
                     f"This issue has been assigned to @{commenter}"
@@ -347,7 +321,7 @@ class IssueAssignmentBot(GitHubBot):
                             " auto-assignment"
                         )
                         continue
-                    current_assignees = self._get_assignee_logins(issue)
+                    current_assignees = get_assignee_logins(issue)
                     if current_assignees:
                         if user_in_logins(pr_author, current_assignees):
                             print(
@@ -362,7 +336,7 @@ class IssueAssignmentBot(GitHubBot):
                             )
                         continue
                     issue.add_to_assignees(pr_author)
-                    verified = self._verify_assignment(issue_number, pr_author)
+                    verified = verify_assignment(self.repo, issue_number, pr_author)
                     if verified is True:
                         assigned_issues.append(issue_number)
                         print(f"Assigned issue #{issue_number} to {pr_author}")

--- a/.github/actions/bot-autoassign/pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/pr_reopen_bot.py
@@ -2,15 +2,16 @@ import json
 import os
 
 from base import GitHubBot
-from utils import get_valid_linked_issues
+from utils import extract_linked_issues, get_valid_linked_issues
 
 
 class PRReopenBot(GitHubBot):
     def reassign_issues_to_author(self, pr_number, pr_author, pr_body):
         try:
             reassigned_issues = []
+            linked_issues = extract_linked_issues(pr_body)
             for issue_number, issue in get_valid_linked_issues(
-                self.repo, self.repository_name, pr_body
+                self.repo, self.repository_name, linked_issues
             ):
                 try:
                     current_assignees = [
@@ -128,8 +129,9 @@ class PRActivityBot(GitHubBot):
             except Exception as e:
                 print(f"Could not remove stale label: {e}")
             reassigned_count = 0
+            linked_issues = extract_linked_issues(pr.body or "")
             for issue_number, issue in get_valid_linked_issues(
-                self.repo, self.repository_name, pr.body or ""
+                self.repo, self.repository_name, linked_issues
             ):
                 try:
                     current_assignees = [

--- a/.github/actions/bot-autoassign/pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/pr_reopen_bot.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from base import GitHubBot
-from utils import extract_linked_issues, get_valid_linked_issues
+from utils import extract_linked_issues, get_valid_linked_issues, user_in_logins
 
 
 class PRReopenBot(GitHubBot):
@@ -19,14 +19,16 @@ class PRReopenBot(GitHubBot):
                         for assignee in issue.assignees
                         if hasattr(assignee, "login")
                     ]
-                    if current_assignees and pr_author not in current_assignees:
+                    if current_assignees and not user_in_logins(
+                        pr_author, current_assignees
+                    ):
                         print(
                             f"Issue #{issue_number} is assigned"
                             " to others:"
                             f' {", ".join(current_assignees)}'
                         )
                         continue
-                    if pr_author not in current_assignees:
+                    if not user_in_logins(pr_author, current_assignees):
                         issue.add_to_assignees(pr_author)
                         reassigned_issues.append(issue_number)
                         print(f"Reassigned issue #{issue_number}" f" to {pr_author}")
@@ -116,7 +118,7 @@ class PRActivityBot(GitHubBot):
                 print("Comment is on an issue," " not a PR, skipping")
                 return True
             pr = self.repo.get_pull(pr_number)
-            if not pr.user or commenter != pr.user.login:
+            if not pr.user or not user_in_logins(commenter, [pr.user.login]):
                 print("Comment not from PR author, skipping")
                 return True
             labels = [label.name for label in pr.get_labels()]

--- a/.github/actions/bot-autoassign/pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/pr_reopen_bot.py
@@ -2,7 +2,13 @@ import json
 import os
 
 from base import GitHubBot
-from utils import extract_linked_issues, get_valid_linked_issues, user_in_logins
+from utils import (
+    extract_linked_issues,
+    get_assignee_logins,
+    get_valid_linked_issues,
+    user_in_logins,
+    verify_assignment,
+)
 
 
 class PRReopenBot(GitHubBot):
@@ -14,11 +20,7 @@ class PRReopenBot(GitHubBot):
                 self.repo, self.repository_name, linked_issues
             ):
                 try:
-                    current_assignees = [
-                        assignee.login
-                        for assignee in issue.assignees
-                        if hasattr(assignee, "login")
-                    ]
+                    current_assignees = get_assignee_logins(issue)
                     if current_assignees and not user_in_logins(
                         pr_author, current_assignees
                     ):
@@ -28,19 +30,29 @@ class PRReopenBot(GitHubBot):
                             f' {", ".join(current_assignees)}'
                         )
                         continue
-                    if not user_in_logins(pr_author, current_assignees):
-                        issue.add_to_assignees(pr_author)
-                        reassigned_issues.append(issue_number)
-                        print(f"Reassigned issue #{issue_number}" f" to {pr_author}")
-                        welcome_message = (
-                            f"Welcome back, @{pr_author}! 🎉"
-                            " This issue has been reassigned"
-                            " to you as you've reopened"
-                            f" PR #{pr_number}."
+                    if user_in_logins(pr_author, current_assignees):
+                        continue
+                    issue.add_to_assignees(pr_author)
+                    if (
+                        verify_assignment(self.repo, issue_number, pr_author)
+                        is not True
+                    ):
+                        print(
+                            f"Reassign of #{issue_number} to {pr_author}"
+                            " was silently rejected or unverifiable."
                         )
-                        issue.create_comment(welcome_message)
+                        continue
+                    reassigned_issues.append(issue_number)
+                    print(f"Reassigned issue #{issue_number} to {pr_author}")
+                    welcome_message = (
+                        f"Welcome back, @{pr_author}! 🎉"
+                        " This issue has been reassigned"
+                        " to you as you've reopened"
+                        f" PR #{pr_number}."
+                    )
+                    issue.create_comment(welcome_message)
                 except Exception as e:
-                    print(f"Error processing issue" f" #{issue_number}: {e}")
+                    print(f"Error processing issue #{issue_number}: {e}")
             return reassigned_issues
         except Exception as e:
             print(f"Error in reassign_issues_to_author: {e}")
@@ -136,17 +148,22 @@ class PRActivityBot(GitHubBot):
                 self.repo, self.repository_name, linked_issues
             ):
                 try:
-                    current_assignees = [
-                        assignee.login
-                        for assignee in issue.assignees
-                        if hasattr(assignee, "login")
-                    ]
-                    if not current_assignees:
-                        issue.add_to_assignees(commenter)
-                        reassigned_count += 1
-                        print(f"Reassigned issue #{issue_number}" f" to {commenter}")
+                    if get_assignee_logins(issue):
+                        continue
+                    issue.add_to_assignees(commenter)
+                    if (
+                        verify_assignment(self.repo, issue_number, commenter)
+                        is not True
+                    ):
+                        print(
+                            f"Reassign of #{issue_number} to {commenter}"
+                            " was silently rejected or unverifiable."
+                        )
+                        continue
+                    reassigned_count += 1
+                    print(f"Reassigned issue #{issue_number} to {commenter}")
                 except Exception as e:
-                    print(f"Error reassigning issue" f" #{issue_number}: {e}")
+                    print(f"Error reassigning issue #{issue_number}: {e}")
             if reassigned_count > 0:
                 encouragement_message = (
                     f"Thanks for following up, @{commenter}! 🙌"

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -669,6 +669,12 @@ class TestIsBotAssignCommand:
         bot = IssueAssignmentBot()
         assert not bot.is_bot_assign_command(comment)
 
+    def test_respects_custom_bot_username(self, monkeypatch, bot_env):
+        monkeypatch.setenv("BOT_USERNAME", "custom-bot")
+        bot = IssueAssignmentBot()
+        assert bot.is_bot_assign_command("@custom-bot assign")
+        assert not bot.is_bot_assign_command("@openwisp-companion assign")
+
 
 class TestHandleBotAssignRequest:
     def test_assigns_when_open_pr_exists(self, bot_env):

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -226,6 +226,7 @@ class TestAutoAssignIssuesFromPR:
     def test_silent_failure_posts_fallback_message(self, bot_env):
         bot = IssueAssignmentBot()
         mock_issue = Mock()
+        mock_issue.state = "open"
         mock_issue.labels = []
         mock_issue.pull_request = None
         mock_issue.assignees = []

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -24,6 +24,7 @@ def bot_env(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "test_token")
     monkeypatch.setenv("REPOSITORY", "openwisp/openwisp-utils")
     monkeypatch.setenv("GITHUB_EVENT_NAME", "issue_comment")
+    monkeypatch.setattr("issue_assignment_bot.time.sleep", lambda _seconds: None)
     with patch("base.Github") as mock_github_cls:
         mock_repo = Mock()
         mock_github_cls.return_value.get_repo.return_value = mock_repo
@@ -103,6 +104,24 @@ class TestExtractLinkedIssues:
         result = extract_linked_issues(pr_body)
         assert sorted(result) == sorted(expected)
 
+    @pytest.mark.parametrize(
+        "pr_body,expected",
+        [
+            ("Fixes #123", [123]),
+            ("Closes #456 and resolves #789", [456, 789]),
+            ("Fixed #999", [999]),
+            ("Related to #99", []),  # excluded in strict mode
+            ("Relates to #42", []),  # excluded in strict mode
+            ("Fixes #1 and related to #2", [1]),
+            ("", []),
+        ],
+    )
+    def test_extract_linked_issues_strict(self, pr_body, expected, bot_env):
+        from utils import extract_linked_issues
+
+        result = extract_linked_issues(pr_body, strict=True)
+        assert sorted(result) == sorted(expected)
+
 
 class TestRespondToAssignment:
     def test_success_no_type_detected(self, bot_env):
@@ -154,25 +173,131 @@ class TestRespondToAssignment:
         assert not bot.respond_to_assignment_request(123, "testuser")
 
 
+def _make_issue_with_assignment(
+    login="testuser", repo_full_name="openwisp/openwisp-utils"
+):
+    mock_issue = Mock()
+    mock_issue.labels = []
+    mock_issue.title = "Test issue"
+    mock_issue.body = "Test body"
+    mock_issue.pull_request = None
+    mock_issue.state = "open"
+    mock_issue.assignees = []
+    mock_issue.repository.full_name = repo_full_name
+
+    def _assign(user):
+        assignee = Mock()
+        assignee.login = user
+        mock_issue.assignees = [*mock_issue.assignees, assignee]
+
+    mock_issue.add_to_assignees.side_effect = _assign
+    return mock_issue
+
+
+def _make_bot_assign_issue(
+    state="open",
+    pull_request=None,
+    assignees=None,
+    repo_full_name="openwisp/openwisp-utils",
+):
+    mock_issue = Mock()
+    mock_issue.state = state
+    mock_issue.pull_request = pull_request
+    mock_issue.assignees = list(assignees or [])
+    mock_issue.repository.full_name = repo_full_name
+    return mock_issue
+
+
 class TestAutoAssignIssuesFromPR:
     def test_success(self, bot_env):
         bot = IssueAssignmentBot()
+        issues_by_number = {
+            123: _make_issue_with_assignment("testuser"),
+            456: _make_issue_with_assignment("testuser"),
+        }
+        bot_env["repo"].get_issue.side_effect = lambda n: issues_by_number[n]
+        assigned = bot.auto_assign_issues_from_pr(
+            100, "testuser", "This PR fixes #123 and closes #456"
+        )
+        assert sorted(assigned) == [123, 456]
+        for issue in issues_by_number.values():
+            issue.add_to_assignees.assert_called_once_with("testuser")
+            issue.create_comment.assert_called_once()
+            assert "automatically assigned" in issue.create_comment.call_args[0][0]
+
+    def test_silent_failure_posts_fallback_message(self, bot_env):
+        bot = IssueAssignmentBot()
         mock_issue = Mock()
         mock_issue.labels = []
-        mock_issue.title = "Test issue"
-        mock_issue.body = "Test body"
         mock_issue.pull_request = None
         mock_issue.assignees = []
         mock_issue.repository.full_name = "openwisp/openwisp-utils"
         bot_env["repo"].get_issue.return_value = mock_issue
-        assigned = bot.auto_assign_issues_from_pr(
-            100, "testuser", "This PR fixes #123 and closes #456"
-        )
-        assert len(assigned) == 2
-        assert 123 in assigned
-        assert 456 in assigned
-        assert mock_issue.add_to_assignees.call_count == 2
-        mock_issue.add_to_assignees.assert_any_call("testuser")
+        assigned = bot.auto_assign_issues_from_pr(100, "nonmember", "Fixes #123")
+        assert assigned == []
+        mock_issue.add_to_assignees.assert_called_once_with("nonmember")
+        mock_issue.create_comment.assert_called_once()
+        fallback = mock_issue.create_comment.call_args[0][0]
+        assert "@nonmember" in fallback
+        assert "openwisp-companion assign" in fallback
+        assert "automatically assigned" not in fallback
+
+    def test_verification_error_stays_silent(self, bot_env):
+        from github import GithubException
+
+        bot = IssueAssignmentBot()
+        initial_issue = Mock()
+        initial_issue.labels = []
+        initial_issue.pull_request = None
+        initial_issue.assignees = []
+        initial_issue.repository.full_name = "openwisp/openwisp-utils"
+        transient = GithubException(500, "transient", headers=None)
+        bot_env["repo"].get_issue.side_effect = [
+            initial_issue,
+            transient,
+            transient,
+        ]
+        assigned = bot.auto_assign_issues_from_pr(100, "someuser", "Fixes #123")
+        assert assigned == []
+        initial_issue.add_to_assignees.assert_called_once_with("someuser")
+        initial_issue.create_comment.assert_not_called()
+
+    def test_verification_retries_on_transient_lag(self, bot_env):
+        bot = IssueAssignmentBot()
+        initial_issue = Mock()
+        initial_issue.labels = []
+        initial_issue.pull_request = None
+        initial_issue.assignees = []
+        initial_issue.repository.full_name = "openwisp/openwisp-utils"
+        stale_issue = Mock()
+        stale_issue.assignees = []
+        fresh_assignee = Mock()
+        fresh_assignee.login = "someuser"
+        fresh_issue = Mock()
+        fresh_issue.assignees = [fresh_assignee]
+        bot_env["repo"].get_issue.side_effect = [
+            initial_issue,
+            stale_issue,
+            fresh_issue,
+        ]
+        assigned = bot.auto_assign_issues_from_pr(100, "someuser", "Fixes #123")
+        assert assigned == [123]
+        initial_issue.create_comment.assert_called_once()
+        assert "automatically assigned" in initial_issue.create_comment.call_args[0][0]
+
+    def test_skip_closed_issue_in_pr_flow(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = Mock()
+        mock_issue.labels = []
+        mock_issue.pull_request = None
+        mock_issue.state = "closed"
+        mock_issue.assignees = []
+        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assigned = bot.auto_assign_issues_from_pr(100, "someuser", "Fixes #123")
+        assert assigned == []
+        mock_issue.add_to_assignees.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
 
     def test_skip_already_assigned(self, bot_env):
         bot = IssueAssignmentBot()
@@ -200,11 +325,10 @@ class TestAutoAssignIssuesFromPR:
     def test_rate_limiting(self, bot_env):
         bot = IssueAssignmentBot()
         issue_refs = " ".join([f"fixes #{i}" for i in range(1, 16)])
-        mock_issue = Mock()
-        mock_issue.pull_request = None
-        mock_issue.assignees = []
-        mock_issue.repository.full_name = "openwisp/openwisp-utils"
-        bot_env["repo"].get_issue.return_value = mock_issue
+        issues_by_number = {
+            n: _make_issue_with_assignment("testuser") for n in range(1, 16)
+        }
+        bot_env["repo"].get_issue.side_effect = lambda n: issues_by_number[n]
         assigned = bot.auto_assign_issues_from_pr(
             100, "testuser", issue_refs, max_issues=10
         )
@@ -324,10 +448,7 @@ class TestHandlePullRequest:
                 },
             }
         )
-        mock_issue = Mock()
-        mock_issue.pull_request = None
-        mock_issue.assignees = []
-        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        mock_issue = _make_issue_with_assignment("testuser")
         bot_env["repo"].get_issue.return_value = mock_issue
         assert bot.handle_pull_request()
         mock_issue.add_to_assignees.assert_called_once_with("testuser")
@@ -344,10 +465,7 @@ class TestHandlePullRequest:
                 },
             }
         )
-        mock_issue = Mock()
-        mock_issue.pull_request = None
-        mock_issue.assignees = []
-        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        mock_issue = _make_issue_with_assignment("testuser")
         bot_env["repo"].get_issue.return_value = mock_issue
         assert bot.handle_pull_request()
 
@@ -437,10 +555,7 @@ class TestRun:
                 },
             }
         )
-        mock_issue = Mock()
-        mock_issue.pull_request = None
-        mock_issue.assignees = []
-        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        mock_issue = _make_issue_with_assignment("testuser")
         bot_env["repo"].get_issue.return_value = mock_issue
         assert bot.run()
 
@@ -454,3 +569,249 @@ class TestRun:
         bot.github = None
         bot.repo = None
         assert not bot.run()
+
+
+class TestIsBotAssignCommand:
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "@openwisp-companion assign",
+            "@openwisp-companion assign me",
+            "hey @openwisp-companion assign please",
+            "@OpenWISP-Companion ASSIGN",
+        ],
+    )
+    def test_positive_cases(self, comment, bot_env):
+        bot = IssueAssignmentBot()
+        assert bot.is_bot_assign_command(comment)
+
+    @pytest.mark.parametrize(
+        "comment",
+        [
+            "assign me please",
+            "@openwisp-companion hello",
+            "@someone-else assign",
+            "assign @openwisp-companion",
+            # regex word-boundary precision — substrings must not match
+            "@openwisp-companion assignee",
+            "@openwisp-companion assigning",
+            "@openwisp-companion assigns",
+            "@openwisp-companion assignment",
+            "",
+            None,
+        ],
+    )
+    def test_negative_cases(self, comment, bot_env):
+        bot = IssueAssignmentBot()
+        assert not bot.is_bot_assign_command(comment)
+
+
+class TestHandleBotAssignRequest:
+    def test_assigns_when_open_pr_exists(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_issue_with_assignment("contributor")
+        mock_pr = Mock()
+        mock_pr.number = 200
+        mock_pr.user.login = "contributor"
+        mock_pr.body = "Fixes #123"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_called_once_with("contributor")
+        mock_issue.create_comment.assert_called_once()
+        comment = mock_issue.create_comment.call_args[0][0]
+        assert "assigned to @contributor" in comment
+        assert "PR #200" in comment
+
+    def test_replies_when_no_open_pr(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_bot_assign_issue()
+        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo"].get_pulls.return_value = []
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_not_called()
+        mock_issue.create_comment.assert_called_once()
+        comment_text = mock_issue.create_comment.call_args[0][0]
+        assert "could not find an open PR" in comment_text
+
+    def test_skip_if_already_assigned(self, bot_env):
+        bot = IssueAssignmentBot()
+        existing = Mock()
+        existing.login = "contributor"
+        mock_issue = _make_bot_assign_issue(assignees=[existing])
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
+
+    def test_skip_if_already_assigned_case_insensitive(self, bot_env):
+        bot = IssueAssignmentBot()
+        existing = Mock()
+        existing.login = "Contributor"
+        mock_issue = _make_bot_assign_issue(assignees=[existing])
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_not_called()
+
+    def test_skip_if_issue_closed(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_bot_assign_issue(state="closed")
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
+
+    def test_skip_if_cross_repo_issue(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_bot_assign_issue(repo_full_name="other-org/other-repo")
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
+
+    def test_matches_pr_author_case_insensitively(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_issue_with_assignment("contributor")
+        mock_pr = Mock()
+        mock_pr.number = 200
+        mock_pr.user.login = "Contributor"
+        mock_pr.body = "Fixes #123"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_called_once_with("contributor")
+
+    def test_skip_if_target_is_pr(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_bot_assign_issue(pull_request={"url": "x"})
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_not_called()
+
+    def test_still_silently_rejected(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_bot_assign_issue()
+        mock_pr = Mock()
+        mock_pr.number = 200
+        mock_pr.user.login = "contributor"
+        mock_pr.body = "Fixes #123"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_called_once_with("contributor")
+        comment_text = mock_issue.create_comment.call_args[0][0]
+        assert "manually" in comment_text
+
+    def test_ignores_related_to_pr_reference(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_bot_assign_issue()
+        mock_pr = Mock()
+        mock_pr.number = 200
+        mock_pr.user.login = "contributor"
+        mock_pr.body = "Related to #123"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_not_called()
+        comment_text = mock_issue.create_comment.call_args[0][0]
+        assert "could not find an open PR" in comment_text
+
+
+class TestHandleIssueCommentBotCommand:
+    def test_bot_command_triggers_assign(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.load_event_payload(
+            {
+                "issue": {"number": 123, "pull_request": None},
+                "comment": {
+                    "body": "@openwisp-companion assign",
+                    "user": {"login": "contributor"},
+                },
+            }
+        )
+        mock_issue = _make_issue_with_assignment("contributor")
+        mock_pr = Mock()
+        mock_pr.number = 200
+        mock_pr.user.login = "contributor"
+        mock_pr.body = "Fixes #123"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        assert bot.handle_issue_comment()
+        mock_issue.add_to_assignees.assert_called_once_with("contributor")
+
+    def test_ignores_bot_own_comments(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.load_event_payload(
+            {
+                "issue": {"number": 123, "pull_request": None},
+                "comment": {
+                    "body": "@openwisp-companion assign",
+                    "user": {"login": "openwisp-companion[bot]"},
+                },
+            }
+        )
+        assert bot.handle_issue_comment()
+        bot_env["repo"].get_issue.assert_not_called()
+
+    def test_ignores_comments_with_bot_type(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.load_event_payload(
+            {
+                "issue": {"number": 123, "pull_request": None},
+                "comment": {
+                    "body": "@openwisp-companion assign",
+                    "user": {"login": "some-other-bot[bot]", "type": "Bot"},
+                },
+            }
+        )
+        assert bot.handle_issue_comment()
+        bot_env["repo"].get_issue.assert_not_called()
+
+    def test_ignores_comments_from_github_app(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.load_event_payload(
+            {
+                "issue": {"number": 123, "pull_request": None},
+                "comment": {
+                    "body": "@openwisp-companion assign",
+                    "user": {"login": "someuser"},
+                    "performed_via_github_app": {"id": 1},
+                },
+            }
+        )
+        assert bot.handle_issue_comment()
+        bot_env["repo"].get_issue.assert_not_called()
+
+    def test_ignores_edited_comments(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.load_event_payload(
+            {
+                "action": "edited",
+                "issue": {"number": 123, "pull_request": None},
+                "comment": {
+                    "body": "@openwisp-companion assign",
+                    "user": {"login": "contributor"},
+                },
+            }
+        )
+        assert bot.handle_issue_comment()
+        bot_env["repo"].get_issue.assert_not_called()
+
+    def test_bot_fallback_message_does_not_self_trigger(self, bot_env):
+        bot = IssueAssignmentBot()
+        fallback = bot._build_silent_failure_message("contributor", 200)
+        bot.load_event_payload(
+            {
+                "action": "created",
+                "issue": {"number": 123, "pull_request": None},
+                "comment": {
+                    "body": fallback,
+                    "user": {
+                        "login": "openwisp-companion[bot]",
+                        "type": "Bot",
+                    },
+                },
+            }
+        )
+        assert bot.handle_issue_comment()
+        bot_env["repo"].get_issue.assert_not_called()

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest  # noqa: E402
+from github import GithubException  # noqa: E402
 
 try:
     from issue_assignment_bot import IssueAssignmentBot  # noqa: E402
@@ -27,9 +28,11 @@ def bot_env(monkeypatch):
     monkeypatch.setattr("issue_assignment_bot.time.sleep", lambda _seconds: None)
     with patch("base.Github") as mock_github_cls:
         mock_repo = Mock()
-        mock_github_cls.return_value.get_repo.return_value = mock_repo
+        mock_github = mock_github_cls.return_value
+        mock_github.get_repo.return_value = mock_repo
         yield {
             "github_cls": mock_github_cls,
+            "github": mock_github,
             "repo": mock_repo,
         }
 
@@ -102,24 +105,6 @@ class TestExtractLinkedIssues:
         from utils import extract_linked_issues
 
         result = extract_linked_issues(pr_body)
-        assert sorted(result) == sorted(expected)
-
-    @pytest.mark.parametrize(
-        "pr_body,expected",
-        [
-            ("Fixes #123", [123]),
-            ("Closes #456 and resolves #789", [456, 789]),
-            ("Fixed #999", [999]),
-            ("Related to #99", []),  # excluded in strict mode
-            ("Relates to #42", []),  # excluded in strict mode
-            ("Fixes #1 and related to #2", [1]),
-            ("", []),
-        ],
-    )
-    def test_extract_linked_issues_strict(self, pr_body, expected, bot_env):
-        from utils import extract_linked_issues
-
-        result = extract_linked_issues(pr_body, strict=True)
         assert sorted(result) == sorted(expected)
 
 
@@ -208,6 +193,19 @@ def _make_bot_assign_issue(
     return mock_issue
 
 
+def _make_search_result(number, body, user_login="contributor"):
+    mock_pr = Mock()
+    mock_pr.number = number
+    mock_pr.user.login = user_login
+    mock_pr.body = body
+    mock_issue = Mock()
+    mock_issue.body = body
+    mock_issue.number = number
+    mock_issue.user.login = user_login
+    mock_issue.as_pull_request.return_value = mock_pr
+    return mock_issue
+
+
 class TestAutoAssignIssuesFromPR:
     def test_success(self, bot_env):
         bot = IssueAssignmentBot()
@@ -243,8 +241,6 @@ class TestAutoAssignIssuesFromPR:
         assert "automatically assigned" not in fallback
 
     def test_verification_error_stays_silent(self, bot_env):
-        from github import GithubException
-
         bot = IssueAssignmentBot()
         initial_issue = Mock()
         initial_issue.labels = []
@@ -298,6 +294,62 @@ class TestAutoAssignIssuesFromPR:
         assert assigned == []
         mock_issue.add_to_assignees.assert_not_called()
         mock_issue.create_comment.assert_not_called()
+
+    def test_verification_recovers_then_reports_failure(self, bot_env):
+        bot = IssueAssignmentBot()
+        initial_issue = Mock()
+        initial_issue.labels = []
+        initial_issue.pull_request = None
+        initial_issue.assignees = []
+        initial_issue.repository.full_name = "openwisp/openwisp-utils"
+        stale_issue = Mock()
+        stale_issue.assignees = []
+        bot_env["repo"].get_issue.side_effect = [
+            initial_issue,
+            GithubException(500, "transient", headers=None),
+            stale_issue,
+        ]
+        assigned = bot.auto_assign_issues_from_pr(100, "someuser", "Fixes #123")
+        assert assigned == []
+        initial_issue.create_comment.assert_called_once()
+        fallback = initial_issue.create_comment.call_args[0][0]
+        assert "openwisp-companion assign" in fallback
+
+    def test_verification_catches_non_github_exception(self, bot_env):
+        bot = IssueAssignmentBot()
+        initial_issue = Mock()
+        initial_issue.labels = []
+        initial_issue.pull_request = None
+        initial_issue.assignees = []
+        initial_issue.repository.full_name = "openwisp/openwisp-utils"
+        bot_env["repo"].get_issue.side_effect = [
+            initial_issue,
+            RuntimeError("network dropped"),
+            RuntimeError("network dropped"),
+        ]
+        assigned = bot.auto_assign_issues_from_pr(100, "someuser", "Fixes #123")
+        assert assigned == []
+        initial_issue.create_comment.assert_not_called()
+
+    def test_verification_first_fetch_authoritative(self, bot_env):
+        bot = IssueAssignmentBot()
+        initial_issue = Mock()
+        initial_issue.labels = []
+        initial_issue.pull_request = None
+        initial_issue.assignees = []
+        initial_issue.repository.full_name = "openwisp/openwisp-utils"
+        stale_issue = Mock()
+        stale_issue.assignees = []
+        bot_env["repo"].get_issue.side_effect = [
+            initial_issue,
+            stale_issue,
+            RuntimeError("network dropped"),
+        ]
+        assigned = bot.auto_assign_issues_from_pr(100, "someuser", "Fixes #123")
+        assert assigned == []
+        initial_issue.create_comment.assert_called_once()
+        fallback = initial_issue.create_comment.call_args[0][0]
+        assert "openwisp-companion assign" in fallback
 
     def test_skip_already_assigned(self, bot_env):
         bot = IssueAssignmentBot()
@@ -377,6 +429,19 @@ class TestUnassignIssuesFromPR:
         unassigned = bot.unassign_issues_from_pr("Fixes #123", "testuser")
         assert len(unassigned) == 0
         mock_issue.remove_from_assignees.assert_not_called()
+
+    def test_unassign_matches_case_insensitively(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_assignee = Mock()
+        mock_assignee.login = "TestUser"
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.assignees = [mock_assignee]
+        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        unassigned = bot.unassign_issues_from_pr("Fixes #123", "testuser")
+        assert 123 in unassigned
+        mock_issue.remove_from_assignees.assert_called_once_with("testuser")
 
 
 class TestHandleIssueComment:
@@ -592,7 +657,6 @@ class TestIsBotAssignCommand:
             "@openwisp-companion hello",
             "@someone-else assign",
             "assign @openwisp-companion",
-            # regex word-boundary precision — substrings must not match
             "@openwisp-companion assignee",
             "@openwisp-companion assigning",
             "@openwisp-companion assigns",
@@ -610,12 +674,10 @@ class TestHandleBotAssignRequest:
     def test_assigns_when_open_pr_exists(self, bot_env):
         bot = IssueAssignmentBot()
         mock_issue = _make_issue_with_assignment("contributor")
-        mock_pr = Mock()
-        mock_pr.number = 200
-        mock_pr.user.login = "contributor"
-        mock_pr.body = "Fixes #123"
         bot_env["repo"].get_issue.return_value = mock_issue
-        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        bot_env["github"].search_issues.return_value = [
+            _make_search_result(200, "Fixes #123")
+        ]
         assert bot.handle_bot_assign_request(123, "contributor")
         mock_issue.add_to_assignees.assert_called_once_with("contributor")
         mock_issue.create_comment.assert_called_once()
@@ -627,12 +689,23 @@ class TestHandleBotAssignRequest:
         bot = IssueAssignmentBot()
         mock_issue = _make_bot_assign_issue()
         bot_env["repo"].get_issue.return_value = mock_issue
-        bot_env["repo"].get_pulls.return_value = []
+        bot_env["github"].search_issues.return_value = []
         assert bot.handle_bot_assign_request(123, "contributor")
         mock_issue.add_to_assignees.assert_not_called()
         mock_issue.create_comment.assert_called_once()
         comment_text = mock_issue.create_comment.call_args[0][0]
         assert "could not find an open PR" in comment_text
+
+    def test_stays_silent_when_search_errors(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_issue = _make_bot_assign_issue()
+        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["github"].search_issues.side_effect = GithubException(
+            500, "transient", headers=None
+        )
+        assert bot.handle_bot_assign_request(123, "contributor")
+        mock_issue.add_to_assignees.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
 
     def test_skip_if_already_assigned(self, bot_env):
         bot = IssueAssignmentBot()
@@ -672,12 +745,10 @@ class TestHandleBotAssignRequest:
     def test_matches_pr_author_case_insensitively(self, bot_env):
         bot = IssueAssignmentBot()
         mock_issue = _make_issue_with_assignment("contributor")
-        mock_pr = Mock()
-        mock_pr.number = 200
-        mock_pr.user.login = "Contributor"
-        mock_pr.body = "Fixes #123"
         bot_env["repo"].get_issue.return_value = mock_issue
-        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        bot_env["github"].search_issues.return_value = [
+            _make_search_result(200, "Fixes #123", user_login="Contributor")
+        ]
         assert bot.handle_bot_assign_request(123, "contributor")
         mock_issue.add_to_assignees.assert_called_once_with("contributor")
 
@@ -691,30 +762,24 @@ class TestHandleBotAssignRequest:
     def test_still_silently_rejected(self, bot_env):
         bot = IssueAssignmentBot()
         mock_issue = _make_bot_assign_issue()
-        mock_pr = Mock()
-        mock_pr.number = 200
-        mock_pr.user.login = "contributor"
-        mock_pr.body = "Fixes #123"
         bot_env["repo"].get_issue.return_value = mock_issue
-        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        bot_env["github"].search_issues.return_value = [
+            _make_search_result(200, "Fixes #123")
+        ]
         assert bot.handle_bot_assign_request(123, "contributor")
         mock_issue.add_to_assignees.assert_called_once_with("contributor")
         comment_text = mock_issue.create_comment.call_args[0][0]
         assert "manually" in comment_text
 
-    def test_ignores_related_to_pr_reference(self, bot_env):
+    def test_accepts_related_to_pr_reference(self, bot_env):
         bot = IssueAssignmentBot()
-        mock_issue = _make_bot_assign_issue()
-        mock_pr = Mock()
-        mock_pr.number = 200
-        mock_pr.user.login = "contributor"
-        mock_pr.body = "Related to #123"
+        mock_issue = _make_issue_with_assignment("contributor")
         bot_env["repo"].get_issue.return_value = mock_issue
-        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        bot_env["github"].search_issues.return_value = [
+            _make_search_result(200, "Related to #123")
+        ]
         assert bot.handle_bot_assign_request(123, "contributor")
-        mock_issue.add_to_assignees.assert_not_called()
-        comment_text = mock_issue.create_comment.call_args[0][0]
-        assert "could not find an open PR" in comment_text
+        mock_issue.add_to_assignees.assert_called_once_with("contributor")
 
 
 class TestHandleIssueCommentBotCommand:
@@ -730,12 +795,10 @@ class TestHandleIssueCommentBotCommand:
             }
         )
         mock_issue = _make_issue_with_assignment("contributor")
-        mock_pr = Mock()
-        mock_pr.number = 200
-        mock_pr.user.login = "contributor"
-        mock_pr.body = "Fixes #123"
         bot_env["repo"].get_issue.return_value = mock_issue
-        bot_env["repo"].get_pulls.return_value = [mock_pr]
+        bot_env["github"].search_issues.return_value = [
+            _make_search_result(200, "Fixes #123")
+        ]
         assert bot.handle_issue_comment()
         mock_issue.add_to_assignees.assert_called_once_with("contributor")
 
@@ -799,7 +862,7 @@ class TestHandleIssueCommentBotCommand:
 
     def test_bot_fallback_message_does_not_self_trigger(self, bot_env):
         bot = IssueAssignmentBot()
-        fallback = bot._build_silent_failure_message("contributor", 200)
+        fallback = bot._cannot_auto_assign_message("contributor", 200)
         bot.load_event_payload(
             {
                 "action": "created",

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -25,7 +25,7 @@ def bot_env(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "test_token")
     monkeypatch.setenv("REPOSITORY", "openwisp/openwisp-utils")
     monkeypatch.setenv("GITHUB_EVENT_NAME", "issue_comment")
-    monkeypatch.setattr("issue_assignment_bot.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("utils.time.sleep", lambda _seconds: None)
     with patch("base.Github") as mock_github_cls:
         mock_repo = Mock()
         mock_github = mock_github_cls.return_value

--- a/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
@@ -258,9 +258,12 @@ class TestPRActivityBot:
         mock_issue.pull_request = None
         mock_issue.assignees = []
         mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        _attach_assign_simulation(mock_issue)
         bot_env["repo"].get_issue.return_value = mock_issue
         assert bot.handle_contributor_activity()
         mock_pr.remove_from_labels.assert_called_once_with("stale")
+        mock_issue.add_to_assignees.assert_called_once_with("testuser")
+        mock_pr.create_issue_comment.assert_called_once()
 
     def test_handle_contributor_activity_pr_not_stale(self, bot_env):
         bot = PRActivityBot()

--- a/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
@@ -24,6 +24,7 @@ def bot_env(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "test_token")
     monkeypatch.setenv("REPOSITORY", "openwisp/openwisp-utils")
     monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request_target")
+    monkeypatch.setattr("utils.time.sleep", lambda _seconds: None)
     with patch("base.Github") as mock_github_cls:
         mock_repo = Mock()
         mock_github_cls.return_value.get_repo.return_value = mock_repo
@@ -33,6 +34,16 @@ def bot_env(monkeypatch):
         }
 
 
+def _attach_assign_simulation(mock_issue):
+    def _assign(user):
+        assignee = Mock()
+        assignee.login = user
+        mock_issue.assignees = [*mock_issue.assignees, assignee]
+
+    mock_issue.add_to_assignees.side_effect = _assign
+    return mock_issue
+
+
 class TestPRReopenBot:
     def test_reassign_issues_to_author(self, bot_env):
         bot = PRReopenBot()
@@ -40,6 +51,7 @@ class TestPRReopenBot:
         mock_issue.pull_request = None
         mock_issue.assignees = []
         mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        _attach_assign_simulation(mock_issue)
         bot_env["repo"].get_issue.return_value = mock_issue
         assigned = bot.reassign_issues_to_author(100, "testuser", "Fixes #123")
         assert len(assigned) == 1
@@ -49,6 +61,18 @@ class TestPRReopenBot:
         comment = mock_issue.create_comment.call_args[0][0]
         assert "@testuser" in comment
         assert "PR #100" in comment
+
+    def test_reassign_silent_rejection_skips_welcome_comment(self, bot_env):
+        bot = PRReopenBot()
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.assignees = []
+        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assigned = bot.reassign_issues_to_author(100, "nonmember", "Fixes #123")
+        assert assigned == []
+        mock_issue.add_to_assignees.assert_called_once_with("nonmember")
+        mock_issue.create_comment.assert_not_called()
 
     def test_reassign_skip_already_assigned_by_others(self, bot_env):
         bot = PRReopenBot()
@@ -110,6 +134,7 @@ class TestPRReopenBot:
         mock_issue.pull_request = None
         mock_issue.assignees = []
         mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        _attach_assign_simulation(mock_issue)
         bot_env["repo"].get_issue.return_value = mock_issue
         mock_pr = Mock()
         mock_pr.get_labels.return_value = []
@@ -152,6 +177,7 @@ class TestPRActivityBot:
         mock_issue.pull_request = None
         mock_issue.assignees = []
         mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        _attach_assign_simulation(mock_issue)
         bot_env["repo"].get_issue.return_value = mock_issue
         assert bot.handle_contributor_activity()
         mock_pr.remove_from_labels.assert_called_once_with("stale")
@@ -159,6 +185,36 @@ class TestPRActivityBot:
         mock_pr.create_issue_comment.assert_called_once()
         comment = mock_pr.create_issue_comment.call_args[0][0]
         assert "@testuser" in comment
+
+    def test_handle_contributor_activity_silent_rejection_skips_comment(self, bot_env):
+        bot = PRActivityBot()
+        bot.load_event_payload(
+            {
+                "issue": {
+                    "number": 100,
+                    "pull_request": {
+                        "url": ("https://api.github.com" "/repos/owner/repo/pulls/100")
+                    },
+                },
+                "comment": {"user": {"login": "nonmember"}},
+            }
+        )
+        mock_pr = Mock()
+        mock_pr.user.login = "nonmember"
+        mock_pr.body = "Fixes #123"
+        mock_label = Mock()
+        mock_label.name = "stale"
+        mock_pr.get_labels.return_value = [mock_label]
+        bot_env["repo"].get_pull.return_value = mock_pr
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.assignees = []
+        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assert bot.handle_contributor_activity()
+        mock_pr.remove_from_labels.assert_called_once_with("stale")
+        mock_issue.add_to_assignees.assert_called_once_with("nonmember")
+        mock_pr.create_issue_comment.assert_not_called()
 
     def test_handle_contributor_activity_not_author(self, bot_env):
         bot = PRActivityBot()

--- a/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
@@ -62,6 +62,22 @@ class TestPRReopenBot:
         assigned = bot.reassign_issues_to_author(100, "testuser", "Fixes #123")
         assert len(assigned) == 0
 
+    def test_reassign_skips_when_author_already_assigned_case_insensitive(
+        self, bot_env
+    ):
+        bot = PRReopenBot()
+        mock_assignee = Mock()
+        mock_assignee.login = "TestUser"
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.assignees = [mock_assignee]
+        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assigned = bot.reassign_issues_to_author(100, "testuser", "Fixes #123")
+        assert assigned == []
+        mock_issue.add_to_assignees.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
+
     def test_remove_stale_label(self, bot_env):
         bot = PRReopenBot()
         mock_pr = Mock()
@@ -161,6 +177,34 @@ class TestPRActivityBot:
         mock_pr.user.login = "testuser"
         bot_env["repo"].get_pull.return_value = mock_pr
         assert bot.handle_contributor_activity()
+
+    def test_handle_contributor_activity_author_case_insensitive(self, bot_env):
+        bot = PRActivityBot()
+        bot.load_event_payload(
+            {
+                "issue": {
+                    "number": 100,
+                    "pull_request": {
+                        "url": ("https://api.github.com" "/repos/owner/repo/pulls/100")
+                    },
+                },
+                "comment": {"user": {"login": "testuser"}},
+            }
+        )
+        mock_pr = Mock()
+        mock_pr.user.login = "TestUser"
+        mock_pr.body = "Fixes #123"
+        mock_label = Mock()
+        mock_label.name = "stale"
+        mock_pr.get_labels.return_value = [mock_label]
+        bot_env["repo"].get_pull.return_value = mock_pr
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.assignees = []
+        mock_issue.repository.full_name = "openwisp/openwisp-utils"
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assert bot.handle_contributor_activity()
+        mock_pr.remove_from_labels.assert_called_once_with("stale")
 
     def test_handle_contributor_activity_pr_not_stale(self, bot_env):
         bot = PRActivityBot()

--- a/.github/actions/bot-autoassign/utils.py
+++ b/.github/actions/bot-autoassign/utils.py
@@ -1,11 +1,41 @@
 import re
+import time
 
 from github import GithubException
+
+VERIFICATION_RETRY_DELAY_SECONDS = 1.0
+FIND_OPEN_PR_MAX_RESULTS = 20
 
 
 def user_in_logins(user, logins):
     user_lower = (user or "").lower()
     return any(user_lower == (login or "").lower() for login in logins)
+
+
+def get_assignee_logins(issue):
+    return [a.login for a in issue.assignees if hasattr(a, "login")]
+
+
+def verify_assignment(repo, issue_number, user):
+    """Re-fetch to confirm `user` was assigned. Returns True/False
+    on verified state, None when every fetch errored — caller
+    stays silent on None since the true state is unknown.
+    """
+    had_successful_fetch = False
+    for attempt in range(2):
+        try:
+            updated_issue = repo.get_issue(issue_number)
+            had_successful_fetch = True
+            if user_in_logins(user, get_assignee_logins(updated_issue)):
+                return True
+        except Exception as e:
+            print(
+                f"Error verifying assignment for #{issue_number}"
+                f" (attempt {attempt + 1}/2): {e}"
+            )
+        if attempt == 0:
+            time.sleep(VERIFICATION_RETRY_DELAY_SECONDS)
+    return False if had_successful_fetch else None
 
 
 def extract_linked_issues(pr_body):
@@ -56,7 +86,10 @@ def find_open_pr_for_issue(github, repo_full_name, author, issue_number):
     if not author:
         return None
     query = f"repo:{repo_full_name} is:pr is:open author:{author}"
-    for item in github.search_issues(query, sort="updated", order="desc"):
+    results = github.search_issues(query, sort="updated", order="desc")
+    for index, item in enumerate(results):
+        if index >= FIND_OPEN_PR_MAX_RESULTS:
+            break
         if issue_number in extract_linked_issues(item.body or ""):
             return item.as_pull_request()
     return None
@@ -70,12 +103,7 @@ def unassign_linked_issues_helper(repo, repository_name, pr_body, pr_author):
         repo, repository_name, linked_issues
     ):
         try:
-            current_assignees = [
-                assignee.login
-                for assignee in issue.assignees
-                if hasattr(assignee, "login")
-            ]
-            if user_in_logins(pr_author, current_assignees):
+            if user_in_logins(pr_author, get_assignee_logins(issue)):
                 issue.remove_from_assignees(pr_author)
                 unassigned_issues.append(issue_number)
                 print(f"Unassigned {pr_author} from issue #{issue_number}")

--- a/.github/actions/bot-autoassign/utils.py
+++ b/.github/actions/bot-autoassign/utils.py
@@ -2,32 +2,32 @@ import re
 
 from github import GithubException
 
-_LINK_KEYWORDS_ALL = r"fix(?:e[sd])?|close[sd]?|resolve[sd]?|relat(?:e[sd]?|ed)\s+to"
-_LINK_KEYWORDS_CLOSING = r"fix(?:e[sd])?|close[sd]?|resolve[sd]?"
+
+def user_in_logins(user, logins):
+    user_lower = (user or "").lower()
+    return any(user_lower == (login or "").lower() for login in logins)
 
 
-def extract_linked_issues(pr_body, strict=False):
-    """Extract unique issue numbers referenced in ``pr_body``.
+def extract_linked_issues(pr_body):
+    """Extract issue numbers from PR body.
 
-    By default matches fix/close/resolve/relate-to keywords. With
-    ``strict=True``, excludes relate-to (used when the caller needs
-    to know the PR claims to close the issue, not just reference it).
+    Returns a list of unique issue numbers referenced in the PR body using
+    keywords like 'fixes', 'closes', 'resolves', 'relates to', 'related
+    to'. Supports patterns with optional colons and owner/repo references.
     """
     if not pr_body:
         return []
-    keywords = _LINK_KEYWORDS_CLOSING if strict else _LINK_KEYWORDS_ALL
-    issue_pattern = rf"\b(?:{keywords})\s*:?\s*(?![\w-]+/[\w-]+#)#(\d+)"
+    issue_pattern = (
+        r"\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|relat(?:e[sd]?|ed)\s+to)"
+        r"\s*:?\s*(?![\w-]+/[\w-]+#)#(\d+)"
+    )
     matches = re.findall(issue_pattern, pr_body, re.IGNORECASE)
     return list(dict.fromkeys(int(match) for match in matches))
 
 
-def get_valid_linked_issues(repo, repository_name, pr_body):
+def get_valid_linked_issues(repo, repository_name, issue_numbers):
     """Generator yielding valid linked issues (skipping cross-repo and PRs)."""
-    linked_issues = extract_linked_issues(pr_body)
-    if not linked_issues:
-        return
-
-    for issue_number in linked_issues:
+    for issue_number in issue_numbers:
         try:
             issue = repo.get_issue(issue_number)
             if (
@@ -47,41 +47,35 @@ def get_valid_linked_issues(repo, repository_name, pr_body):
                 print(f"Error fetching issue #{issue_number}: {e}")
 
 
-def find_open_pr_for_issue(repo, author, issue_number, max_prs=100):
+def find_open_pr_for_issue(github, repo_full_name, author, issue_number):
     """Return the most recently updated open PR by ``author`` that
-    closes ``issue_number``, or ``None``.
+    references ``issue_number``, or ``None`` if none is found.
+    Search-API errors propagate so the caller can tell a verified
+    miss from an unknown state.
     """
-    author_lower = (author or "").lower()
-    try:
-        pulls = repo.get_pulls(state="open", sort="updated", direction="desc")
-        for index, pr in enumerate(pulls):
-            if index >= max_prs:
-                print(
-                    f"find_open_pr_for_issue: reached {max_prs}-PR cap"
-                    f" while searching for {author}"
-                )
-                break
-            pr_author = getattr(getattr(pr, "user", None), "login", None) or ""
-            if pr_author.lower() != author_lower:
-                continue
-            if issue_number in extract_linked_issues(pr.body or "", strict=True):
-                return pr
-    except GithubException as e:
-        print(f"GitHub API error searching open PRs by {author}: {e}")
+    if not author:
+        return None
+    query = f"repo:{repo_full_name} is:pr is:open author:{author}"
+    for item in github.search_issues(query, sort="updated", order="desc"):
+        if issue_number in extract_linked_issues(item.body or ""):
+            return item.as_pull_request()
     return None
 
 
 def unassign_linked_issues_helper(repo, repository_name, pr_body, pr_author):
     """Shared helper to unassign linked issues from PR author."""
     unassigned_issues = []
-    for issue_number, issue in get_valid_linked_issues(repo, repository_name, pr_body):
+    linked_issues = extract_linked_issues(pr_body)
+    for issue_number, issue in get_valid_linked_issues(
+        repo, repository_name, linked_issues
+    ):
         try:
             current_assignees = [
                 assignee.login
                 for assignee in issue.assignees
                 if hasattr(assignee, "login")
             ]
-            if pr_author in current_assignees:
+            if user_in_logins(pr_author, current_assignees):
                 issue.remove_from_assignees(pr_author)
                 unassigned_issues.append(issue_number)
                 print(f"Unassigned {pr_author} from issue #{issue_number}")

--- a/.github/actions/bot-autoassign/utils.py
+++ b/.github/actions/bot-autoassign/utils.py
@@ -2,20 +2,21 @@ import re
 
 from github import GithubException
 
+_LINK_KEYWORDS_ALL = r"fix(?:e[sd])?|close[sd]?|resolve[sd]?|relat(?:e[sd]?|ed)\s+to"
+_LINK_KEYWORDS_CLOSING = r"fix(?:e[sd])?|close[sd]?|resolve[sd]?"
 
-def extract_linked_issues(pr_body):
-    """Extract issue numbers from PR body.
 
-    Returns a list of unique issue numbers referenced in the PR body using
-    keywords like 'fixes', 'closes', 'resolves', 'relates to', 'related
-    to'. Supports patterns with optional colons and owner/repo references.
+def extract_linked_issues(pr_body, strict=False):
+    """Extract unique issue numbers referenced in ``pr_body``.
+
+    By default matches fix/close/resolve/relate-to keywords. With
+    ``strict=True``, excludes relate-to (used when the caller needs
+    to know the PR claims to close the issue, not just reference it).
     """
     if not pr_body:
         return []
-    issue_pattern = (
-        r"\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|relat(?:e[sd]?|ed)\s+to)"
-        r"\s*:?\s*(?![\w-]+/[\w-]+#)#(\d+)"
-    )
+    keywords = _LINK_KEYWORDS_CLOSING if strict else _LINK_KEYWORDS_ALL
+    issue_pattern = rf"\b(?:{keywords})\s*:?\s*(?![\w-]+/[\w-]+#)#(\d+)"
     matches = re.findall(issue_pattern, pr_body, re.IGNORECASE)
     return list(dict.fromkeys(int(match) for match in matches))
 
@@ -44,6 +45,30 @@ def get_valid_linked_issues(repo, repository_name, pr_body):
                 print(f"Issue #{issue_number} not found")
             else:
                 print(f"Error fetching issue #{issue_number}: {e}")
+
+
+def find_open_pr_for_issue(repo, author, issue_number, max_prs=100):
+    """Return the most recently updated open PR by ``author`` that
+    closes ``issue_number``, or ``None``.
+    """
+    author_lower = (author or "").lower()
+    try:
+        pulls = repo.get_pulls(state="open", sort="updated", direction="desc")
+        for index, pr in enumerate(pulls):
+            if index >= max_prs:
+                print(
+                    f"find_open_pr_for_issue: reached {max_prs}-PR cap"
+                    f" while searching for {author}"
+                )
+                break
+            pr_author = getattr(getattr(pr, "user", None), "login", None) or ""
+            if pr_author.lower() != author_lower:
+                continue
+            if issue_number in extract_linked_issues(pr.body or "", strict=True):
+                return pr
+    except GithubException as e:
+        print(f"GitHub API error searching open PRs by {author}: {e}")
+    return None
 
 
 def unassign_linked_issues_helper(repo, repository_name, pr_body, pr_author):

--- a/.github/workflows/bot-autoassign-issue.yml
+++ b/.github/workflows/bot-autoassign-issue.yml
@@ -40,6 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          BOT_USERNAME: openwisp-companion
         run: >
           python .github/actions/bot-autoassign/__main__.py
           issue_assignment "$GITHUB_EVENT_PATH"

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}
+  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -41,6 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          BOT_USERNAME: openwisp-companion
         run: >
           python .github/actions/bot-autoassign/__main__.py
           issue_assignment "$GITHUB_EVENT_PATH"

--- a/.github/workflows/reusable-bot-autoassign.yml
+++ b/.github/workflows/reusable-bot-autoassign.yml
@@ -7,6 +7,11 @@ on:
         required: true
         type: string
         description: "The bot to execute (e.g., 'issue_assignment', 'pr_reopen', 'stale_pr')"
+      bot_username:
+        required: false
+        type: string
+        default: "openwisp-companion"
+        description: "The GitHub App username used to detect bot mentions and bot-authored comments"
     secrets:
       OPENWISP_BOT_APP_ID:
         required: true
@@ -45,6 +50,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BOT_COMMAND: ${{ inputs.bot_command }}
+          BOT_USERNAME: ${{ inputs.bot_username }}
         run: |
           if [ -n "$GITHUB_EVENT_PATH" ]; then
             python openwisp-utils/.github/actions/bot-autoassign/__main__.py "$BOT_COMMAND" "$GITHUB_EVENT_PATH"

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -139,7 +139,7 @@ Create the following workflow files in your repository.
       issues: write
       pull-requests: read
     concurrency:
-      group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}
+      group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
       cancel-in-progress: true
     jobs:
       auto-assign-issue:

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -218,6 +218,26 @@ Create the following workflow files in your repository.
           OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
           OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
 
+**Overriding the bot username**
+
+All four caller workflows accept an optional ``bot_username`` input
+(default ``openwisp-companion``). The bot uses it to detect mentions of
+the form ``@<bot_username> assign`` in issue comments and to ignore
+comments authored by the bot itself. Set this if your repository uses a
+different GitHub App username:
+
+.. code-block:: yaml
+
+    jobs:
+      respond-to-assign-request:
+        uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+        with:
+          bot_command: issue_assignment
+          bot_username: my-custom-bot
+        secrets:
+          OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+          OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
+
 GitHub Workflows
 ----------------
 

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -78,7 +78,8 @@ OpenWISP repositories. The bot provides the following features:
 These secrets are used by the workflow to generate a ``GITHUB_TOKEN`` via
 the ``actions/create-github-app-token`` action. The bot itself consumes
 the following environment variables at runtime: ``GITHUB_TOKEN``,
-``REPOSITORY``, and ``GITHUB_EVENT_NAME``.
+``REPOSITORY``, ``GITHUB_EVENT_NAME``, and ``BOT_USERNAME`` (optional;
+defaults to ``openwisp-companion``).
 
 - ``OPENWISP_BOT_APP_ID`` (required): OpenWISP Bot GitHub App ID.
 - ``OPENWISP_BOT_PRIVATE_KEY`` (required): OpenWISP Bot GitHub App private


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #649

Verify assignment actually took effect before posting the confirmation comment. On silent rejection (non-collaborators who have not commented on the issue), post an honest fallback message instructing the user to trigger assignment via the "@openwisp-companion assign" bot command.


## Testing on `bot-testing-ground`

  Workflows on `openwisp/bot-testing-ground@master` temporarily point at this branch
  (commit [`7b24383`](https://github.com/openwisp/bot-testing-ground/commit/7b24383))
  so the silent-rejection and recovery paths can be exercised end-to-end by a
  non-org contributor.

  | Scenario | Issue | PR |
  |---|---|---|
  | Silent-rejection fallback + `@openwisp-companion assign` recovery | openwisp/bot-testing-ground#97 | openwisp/bot-testing-ground#98 |
  | Silent-rejection fallback + `@openwisp-companion assign` recovery (second run) | openwisp/bot-testing-ground#99 | openwisp/bot-testing-ground#100 |


