### PR TITLE
[chores:fix] Removed 'FAILED (' from strict markers to unblock auto-retry

### DIFF
--- a/.github/actions/bot-ci-failure/analyze_failure.py
+++ b/.github/actions/bot-ci-failure/analyze_failure.py
@@ -9,7 +9,6 @@ from google.genai import types
 # Strict markers that unequivocally indicate a failing test or assertion.
 STRICT_TEST_FAILURE_MARKERS = (
     "FAIL:",
-    "FAILED (",
     "AssertionError",
 )
 

--- a/.github/actions/bot-ci-failure/analyze_failure.py
+++ b/.github/actions/bot-ci-failure/analyze_failure.py
@@ -34,7 +34,7 @@ TRANSIENT_FAILURE_MARKERS = (
     "Network is unreachable",
     "Temporary failure in name resolution",
     "selenium.common.exceptions.InvalidSessionIdException",
-    "selenium.common.exceptions.WebDriverException"
+    "selenium.common.exceptions.WebDriverException",
     "Posting coverage data to https://coveralls.io",
     "OperationalError: database is locked",
     "ERROR: Could not install packages due to an OSError",

--- a/.github/actions/bot-ci-failure/analyze_failure.py
+++ b/.github/actions/bot-ci-failure/analyze_failure.py
@@ -34,6 +34,7 @@ TRANSIENT_FAILURE_MARKERS = (
     "Network is unreachable",
     "Temporary failure in name resolution",
     "selenium.common.exceptions.InvalidSessionIdException",
+    "selenium.common.exceptions.WebDriverException"
     "Posting coverage data to https://coveralls.io",
     "OperationalError: database is locked",
     "ERROR: Could not install packages due to an OSError",

--- a/.github/actions/bot-ci-failure/test_analyze_failure.py
+++ b/.github/actions/bot-ci-failure/test_analyze_failure.py
@@ -338,6 +338,20 @@ class TestProcessErrorLogs(unittest.TestCase):
         self.assertTrue(transient_only)
         self.assertFalse(tests_failed)
 
+    def test_transient_ignores_unittest_failed_summary(self):
+        """Ensure unittest's 'FAILED (errors=1)' summary does not override transient crashes."""
+        content = (
+            "===== JOB 5 =====\n"
+            "Traceback (most recent call last):\n"
+            "selenium.common.exceptions.WebDriverException: Message: Reached error page: about:neterror\n"
+            "----------------------------------------------------------------------\n"
+            "Ran 367 tests in 311.148s\n\n"
+            "FAILED (errors=1)\n"
+        )
+        text, tests_failed, transient_only = process_error_logs(content)
+        self.assertFalse(tests_failed)
+        self.assertTrue(transient_only)
+
 
 class TestNormalizeForDedup(unittest.TestCase):
     """Tests for _normalize_for_dedup."""


### PR DESCRIPTION
Removed 'FAILED' keyword from strict failure markers which caused blocking of re-run mechanism

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Existence of 'FAILED' keyword in strict failure markers blocked re-run mechanism due its occurence in any case of failure in CI failure logs.
