### PR TITLE
 System info improvements #376

### DIFF
--- a/openwisp_utils/admin_theme/admin.py
+++ b/openwisp_utils/admin_theme/admin.py
@@ -12,6 +12,7 @@ from . import settings as app_settings
 from .dashboard import get_dashboard_context
 from .system_info import (
     get_enabled_openwisp_modules,
+    get_openwisp_license,
     get_openwisp_version,
     get_os_details,
 )
@@ -40,10 +41,15 @@ class OpenwispAdminSite(admin.AdminSite):
         return super().index(request, extra_context=context)
 
     def openwisp_info(self, request, *args, **kwargs):
+        if not request.user.is_superuser:
+            from django.http import HttpResponseForbidden
+
+            return HttpResponseForbidden()
         context = {
             "enabled_openwisp_modules": get_enabled_openwisp_modules(),
             "system_info": get_os_details(),
             "openwisp_version": get_openwisp_version(),
+            "openwisp_license": get_openwisp_license(),
             "title": _("System Information"),
             "site_title": self.site_title,
         }

--- a/openwisp_utils/admin_theme/apps.py
+++ b/openwisp_utils/admin_theme/apps.py
@@ -61,6 +61,7 @@ class OpenWispAdminThemeConfig(AppConfig):
                 "label": _("System info"),
                 "url": "/admin/openwisp-system-info/",
                 "icon": "ow-info-icon",
+                "permissions": {"superuser_only": True},
             },
         )
 

--- a/openwisp_utils/admin_theme/menu.py
+++ b/openwisp_utils/admin_theme/menu.py
@@ -90,7 +90,8 @@ class ModelLink(BaseMenuItem):
 class MenuLink(BaseMenuItem):
     """Generic Links.
 
-    Creates a link from a custom url Input parameters: label, url, icon.
+    Creates a link from a custom url Input parameters: label, url, icon,
+    permissions.
     """
 
     def __init__(self, config):
@@ -105,6 +106,14 @@ class MenuLink(BaseMenuItem):
             )
         self.url = url
         self.icon = config.get("icon")
+        self.permissions = config.get("permissions", {})
+
+    def create_context(self, request=None):
+        if self.permissions.get("superuser_only") and (
+            request is None or not request.user.is_superuser
+        ):
+            return None
+        return {"label": self.label, "url": self.url, "icon": self.icon}
 
 
 class MenuGroup(BaseMenuItem):

--- a/openwisp_utils/admin_theme/system_info.py
+++ b/openwisp_utils/admin_theme/system_info.py
@@ -1,6 +1,7 @@
 import importlib.metadata
 import platform
 from collections import OrderedDict
+from pathlib import Path
 
 import distro
 from django.conf import settings
@@ -66,3 +67,11 @@ def get_os_details():
         "kernel_version": kernel_version,
         "hardware_platform": uname.machine,
     }
+
+
+def get_openwisp_license():
+    try:
+        license_path = Path(__file__).resolve().parent.parent.parent / "LICENSE"
+        return license_path.read_text()
+    except (FileNotFoundError, OSError):
+        return None

--- a/openwisp_utils/admin_theme/templates/admin/openwisp_info.html
+++ b/openwisp_utils/admin_theme/templates/admin/openwisp_info.html
@@ -21,6 +21,11 @@
 <p><strong>{% trans "Kernel version" %}:</strong> {{ system_info.kernel_version }}</p>
 <p><strong>{% trans "Hardware platform" %}:</strong> {{ system_info.hardware_platform }}</p>
 
+{% if openwisp_license %}
+<h2>{% trans "License" %}</h2>
+<pre>{{ openwisp_license }}</pre>
+{% endif %}
+
 <div id="metric-consent">
 {% block metric_collect_consent %}
   {% if metric_collection_installed %}

--- a/openwisp_utils/metric_collection/tests/test_consent.py
+++ b/openwisp_utils/metric_collection/tests/test_consent.py
@@ -119,7 +119,7 @@ class TestConsent(TestCase):
         self.client.force_login(non_superuser)
         with self.subTest("Test non-superuser makes post request"):
             response = self.client.post(path, {"user_consented": False})
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 403)
             consent_obj.refresh_from_db()
             self.assertEqual(consent_obj.user_consented, True)
 

--- a/tests/test_project/tests/test_admin.py
+++ b/tests/test_project/tests/test_admin.py
@@ -593,3 +593,31 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertNotContains(response, "<h2>OpenWISP Version")
             _assert_system_information(response)
+
+        with self.subTest("Test license is shown"):
+            response = self.client.get(reverse("admin:ow-info"))
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, "<h2>License</h2>")
+            self.assertContains(response, "BSD 3-Clause License")
+
+    def test_system_info_non_superuser_gets_403(self):
+        non_superuser = User.objects.create_user(
+            username="operator",
+            password="operator",
+            email="operator@test.org",
+            is_staff=True,
+        )
+        self.client.force_login(non_superuser)
+        response = self.client.get(reverse("admin:ow-info"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_system_info_menu_hidden_for_non_superuser(self):
+        non_superuser = User.objects.create_user(
+            username="operator2",
+            password="operator2",
+            email="operator2@test.org",
+            is_staff=True,
+        )
+        self.client.force_login(non_superuser)
+        response = self.client.get(reverse("admin:index"))
+        self.assertNotContains(response, "openwisp-system-info")


### PR DESCRIPTION
Added superuser-only permission to the system info page and menu link. Non-superuser staff accounts now receive a 403 when accessing the URL and the System info menu entry is hidden from them entirely.

Added OpenWISP license display in the system info page by reading the LICENSE file from the package root and passing it to the template.

Added permissions support to MenuLink so that menu items can declare superuser_only restriction. The system info menu entry in apps.py uses this new permissions key.

Closes #376

