### PR TITLE
 [fix] Fixed double encoding of device model labels in dashboard #651 

### DIFF
--- a/openwisp_utils/admin_theme/dashboard.py
+++ b/openwisp_utils/admin_theme/dashboard.py
@@ -1,5 +1,6 @@
 import copy
 import html
+from urllib.parse import quote
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Count
@@ -209,10 +210,8 @@ def get_dashboard_context(request):
                 label = qs_key
                 # get human readable label if predefined labels are available
                 # otherwise use the result got from the DB
+                filters.append(quote(label, safe=""))
                 if labels_i18n and qs_key in labels_i18n:
-                    # store original label as filter, but only
-                    # if we have more than the empty default label defined
-                    filters.append(label)
                     label = labels_i18n[qs_key]
                 else:
                     # HTML escape labels coming from values in the DB

--- a/openwisp_utils/admin_theme/dashboard.py
+++ b/openwisp_utils/admin_theme/dashboard.py
@@ -208,9 +208,10 @@ def get_dashboard_context(request):
                     continue
                 qs_key = str(obj[group_by])
                 label = qs_key
+                # add URL quoted label to filters
+                filters.append(quote(label, safe=""))
                 # get human readable label if predefined labels are available
                 # otherwise use the result got from the DB
-                filters.append(quote(label, safe=""))
                 if labels_i18n and qs_key in labels_i18n:
                     label = labels_i18n[qs_key]
                 else:

--- a/tests/test_project/tests/test_dashboard.py
+++ b/tests/test_project/tests/test_dashboard.py
@@ -294,3 +294,30 @@ class TestAdminDashboard(AdminTestMixin, CreateMixin, DjangoTestCase):
             context["dashboard_charts"][1]["query_params"]["labels"][0],
             "&lt;strong&gt;Projects with operators&lt;/strong&gt;",
         )
+
+    def test_filter_not_double_encoded(self):
+        project = Project.objects.create(name="Dongwon T&I")
+        Operator.objects.create(project=project, first_name="test", last_name="test")
+        mocked_user = MockUser(is_superuser=True)
+        mocked_request = MockRequest(user=mocked_user)
+        context = get_dashboard_context(mocked_request)
+        target_chart = None
+        for chart in context["dashboard_charts"].values():
+            if chart.get("name") == "Operator Project Distribution":
+                target_chart = chart
+                break
+        self.assertIsNotNone(target_chart)
+        filters = target_chart.get("filters", [])
+        labels = target_chart.get("query_params", {}).get("labels", [])
+        self.assertIn("Dongwon%20T%26I", filters)
+        self.assertNotIn("Dongwon T&I", filters)
+        self.assertIn("Dongwon T&amp;I", labels)
+        filter_index = None
+        for i, label in enumerate(labels):
+            if "Dongwon" in label:
+                filter_index = i
+                break
+        self.assertIsNotNone(filter_index)
+        final_url = target_chart["target_link"] + filters[filter_index]
+        self.assertNotIn("&I", final_url.split("=", 1)[-1])
+        self.assertIn("%26", final_url)


### PR DESCRIPTION
## Checklist

 I have read the OpenWISP Contributing Guidelines.

I have manually tested the changes proposed in this pull request.

 I have written new test cases for new code and/or updated existing tests for changes to existing code.

 I have updated the documentation.

## Reference to Existing Issue
Fixes #651 

## Description of Changes
Hoisted filters.append Moved the append logic above the if/else block to remove the duplication and keep the code DRY.

Server-side URL Encoding Wrapped the label in quote(label, safe="") from urllib.parse before appending it to filters. This ensures the JS click handler receives a fully URL-encoded string (e.g., %26 instead of &), preventing the URL parsing issue in the browser.

## Local validation:
black openwisp_utils/admin_theme/dashboard.py tests/test_project/tests/test_dashboard.py
python runtests.py test_project.tests.test_dashboard.TestAdminDashboard.test_filter_not_double_encoded -v 2
python runtests.py test_project.tests.test_dashboard.TestAdminDashboard.test_index_content -v 2

## Screenshot

<img width="736" height="95" alt="f1" src="https://github.com/user-attachments/assets/671add33-23b0-498b-a5ef-0ae9a04999a3" />
before fix 

<img width="718" height="50" alt="after fix" src="https://github.com/user-attachments/assets/029247b9-2f60-431d-af33-389c244f7fe3" />
after fix 