### PR TITLE
[tests] Fixed commitizen rules subprocess & coverage

### DIFF
--- a/openwisp_utils/releaser/tests/test_commitizen_rules.py
+++ b/openwisp_utils/releaser/tests/test_commitizen_rules.py
@@ -1,14 +1,37 @@
-import subprocess
+import re
+from types import SimpleNamespace
+
+# ``commitizen.cz`` must be imported before ``openwisp_utils.releaser.commitizen``
+# so its plugin auto-discovery completes first; otherwise discovery re-imports
+# our module mid-initialization and raises AttributeError (issue #669).
+import commitizen.cz  # noqa: F401, E402
+from openwisp_utils.releaser.commitizen import OpenWispCommitizen  # noqa: E402
+
+# Coverage was previously invisible because every test went through the
+# ``cz`` subprocess; calling the plugin in-process keeps the existing
+# assertions but lets the parent process's coverage tracker see the
+# method bodies actually run.
+_PLUGIN = OpenWispCommitizen(SimpleNamespace(settings={}))
+_PATTERN = re.compile(_PLUGIN.schema_pattern())
 
 
 def run_cz_check(message):
-    result = subprocess.run(
-        ["cz", "-n", "cz_openwisp", "check", "--message", message],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+    """In-process equivalent of ``cz -n cz_openwisp check --message ...``.
+
+    Returns ``(returncode, stdout, stderr)`` so the assertions written
+    against the previous subprocess helper still apply.
+    """
+    result = _PLUGIN.validate_commit_message(
+        commit_msg=message,
+        pattern=_PATTERN,
+        allow_abort=False,
+        allowed_prefixes=[],
+        max_msg_length=None,
+        commit_hash="TEST",
     )
-    return result.returncode, result.stdout, result.stderr
+    if result.is_valid:
+        return 0, "commit validation: successful!", ""
+    return 1, "commit validation: failed!\n" + "\n".join(result.errors), ""
 
 
 def test_valid_commit_with_issue():
@@ -146,24 +169,18 @@ def test_issue_in_the_middle():
 
 def test_info_includes_all_prefixes():
     """Check that all expected prefixes are documented."""
-    result = subprocess.run(
-        ["cz", "-n", "cz_openwisp", "info"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    assert result.returncode == 0
-    assert "- feature" in result.stdout
-    assert "- change" in result.stdout
-    assert "- fix" in result.stdout
-    assert "- docs" in result.stdout
-    assert "- tests" in result.stdout
-    assert "- ci" in result.stdout
-    assert "- chores" in result.stdout
-    assert "- qa" in result.stdout
-    assert "- deps" in result.stdout
-    assert "- release" in result.stdout
-    assert "- bump" in result.stdout
+    info = _PLUGIN.info()
+    assert "- feature" in info
+    assert "- change" in info
+    assert "- fix" in info
+    assert "- docs" in info
+    assert "- tests" in info
+    assert "- ci" in info
+    assert "- chores" in info
+    assert "- qa" in info
+    assert "- deps" in info
+    assert "- release" in info
+    assert "- bump" in info
 
 
 def test_error_message_is_user_friendly():
@@ -216,3 +233,85 @@ def test_valid_commit_with_multiple_auto_appended_issues():
     )
     code, out, err = run_cz_check(message)
     assert code == 0, f"Multiple auto-appended issues should be valid: {out + err}"
+
+
+def test_message_no_issue_returns_prefix_and_body():
+    """message() builds a plain commit when neither title nor body reference an issue."""
+    msg = _PLUGIN.message(
+        {"change_type": "chores", "title": "Updated docs", "how": "Did stuff."}
+    )
+    assert msg == "[chores] Updated docs\n\nDid stuff."
+
+
+def test_message_auto_appends_related_to_when_body_missing_issue():
+    """message() auto-appends 'Related to' so the generated commit is symmetric."""
+    msg = _PLUGIN.message(
+        {
+            "change_type": "feature",
+            "title": "Added retries #42",
+            "how": "Adds retry support.",
+        }
+    )
+    assert msg.endswith("Related to #42")
+
+
+def test_message_does_not_duplicate_issue_when_body_already_references_it():
+    """If the user already referenced the issue in the body, nothing is appended."""
+    msg = _PLUGIN.message(
+        {
+            "change_type": "feature",
+            "title": "Added retries #42",
+            "how": "Adds retry support.\n\nFixes #42",
+        }
+    )
+    assert msg.count("#42") == 2  # one in title, one in body
+    assert "Related to" not in msg
+
+
+def test_questions_title_validator_rejects_lowercase():
+    """The title prompt rejects titles that aren't capitalized."""
+    title_validator = _PLUGIN.questions()[1]["validate"]
+    assert title_validator("lowercase") == (
+        "Commit title must start with a capital letter."
+    )
+
+
+def test_questions_title_validator_rejects_empty():
+    """The title prompt rejects empty/whitespace-only input."""
+    title_validator = _PLUGIN.questions()[1]["validate"]
+    assert title_validator("   ") == "Commit title cannot be empty."
+
+
+def test_questions_title_validator_accepts_capitalized():
+    """The title prompt accepts titles that start with a capital letter."""
+    title_validator = _PLUGIN.questions()[1]["validate"]
+    assert title_validator("Capitalized title") is True
+
+
+def test_subject_length_limit_exceeded():
+    """validate_commit_message enforces max_msg_length on the subject line."""
+    long_title = "[fix] X" + ("x" * 100)
+    result = _PLUGIN.validate_commit_message(
+        commit_msg=f"{long_title}\n\nBody.",
+        pattern=_PATTERN,
+        allow_abort=False,
+        allowed_prefixes=[],
+        max_msg_length=72,
+        commit_hash="TEST",
+    )
+    assert result.is_valid is False
+    assert "length" in result.errors[0].lower()
+
+
+def test_format_error_message_returns_user_friendly_template():
+    """format_error_message exposes the worked example, never the raw regex."""
+    rendered = _PLUGIN.format_error_message("anything")
+    assert rendered is OpenWispCommitizen.ERROR_TEMPLATE
+    assert "(?sm)" not in rendered  # raw regex must not leak to users
+
+
+def test_example_and_schema_match_documented_format():
+    """example() and schema() are the strings the CLI surfaces to users."""
+    assert _PLUGIN.example().startswith("[feature]")
+    assert "Fixes #110" in _PLUGIN.example()
+    assert _PLUGIN.schema() == "[<type>] <Title> [#<issue>]"


### PR DESCRIPTION
Converted subprocess-based tests to in-process unit tests to fix the coverage gap. Subprocess-based tests are invisible to the parent's coverage tracker (.coveragerc lacks subprocess instrumentation).

Now follows the pattern from test_commitizen_unit.py: direct instantiation and in-process method calls for coverage visibility.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.