### PR TITLE
[change] Added default uuid method to CopyableFieldsAdmin #328

### DIFF
--- a/docs/developer/admin-utilities.rst
+++ b/docs/developer/admin-utilities.rst
@@ -49,14 +49,12 @@ it easy to copy the fields contents.
 Useful for auto-generated fields such as UUIDs, secret keys, tokens, etc.
 
 To replicate the "copy UUID" behavior previously provided by the removed
-``UUIDAdmin`` class, set ``copyable_fields = ("uuid",)`` on a
-``CopyableFieldsAdmin`` subclass and expose a ``uuid()`` display method,
-for example:
+``UUIDAdmin`` class, just set ``copyable_fields = ("uuid",)`` on a
+``CopyableFieldsAdmin`` subclass:
 
 .. code-block:: python
 
     from django.contrib import admin
-    from django.utils.translation import gettext_lazy as _
     from openwisp_utils.admin import CopyableFieldsAdmin
 
     from .models import MyModel
@@ -65,11 +63,6 @@ for example:
     @admin.register(MyModel)
     class MyModelAdmin(CopyableFieldsAdmin):
         copyable_fields = ("uuid",)
-
-        def uuid(self, obj):
-            return obj.pk
-
-        uuid.short_description = _("UUID")
 
 ``openwisp_utils.admin.ReceiveUrlAdmin``
 ----------------------------------------

--- a/openwisp_utils/admin.py
+++ b/openwisp_utils/admin.py
@@ -130,6 +130,17 @@ class CopyableFieldsAdmin(ModelAdmin):
             extra_context=extra_context,
         )
 
+    def uuid(self, obj):
+        """Return the object's primary key (UUID).
+
+        This default implementation allows subclasses to use
+        copyable_fields = ("uuid",) without defining their own uuid()
+        method when their model uses a UUID primary key.
+        """
+        return obj.pk
+
+    uuid.short_description = _("UUID")
+
     class Media:
         js = ("admin/js/jquery.init.js", "openwisp-utils/js/copyable.js")
 

--- a/tests/test_project/admin.py
+++ b/tests/test_project/admin.py
@@ -88,11 +88,6 @@ class ProjectAdmin(CopyableFieldsAdmin, ReceiveUrlAdmin):
     receive_url_name = "receive_project"
     copyable_fields = ("uuid",)
 
-    def uuid(self, obj):
-        return obj.pk
-
-    uuid.short_description = _("UUID")
-
 
 class ShelfFilter(SimpleInputFilter):
     parameter_name = "shelf"

--- a/tests/test_project/tests/test_admin.py
+++ b/tests/test_project/tests/test_admin.py
@@ -247,6 +247,26 @@ class TestAdmin(AdminTestMixin, CreateMixin, TestCase):
             ma.get_fields(self.client.request)
         self.assertIn(copyable_field_err, err.exception.args[0])
 
+    def test_copyablefields_admin_default_uuid_method(self):
+        """CopyableFieldsAdmin should provide a default uuid method.
+
+        This allows subclasses to use copyable_fields = ("uuid",) without
+        having to define their own uuid() method and short_description.
+        The uuid method should return obj.pk and have short_description
+        "UUID".
+        """
+
+        class TestAdminWithUuid(CopyableFieldsAdmin):
+            copyable_fields = ("uuid",)
+
+        p = Project.objects.create(name="test-default-uuid")
+        ma = TestAdminWithUuid(Project, AdminSite())
+        # Verify the uuid method exists and returns obj.pk
+        self.assertTrue(hasattr(ma, "uuid"))
+        self.assertEqual(ma.uuid(p), p.pk)
+        # Verify short_description is set
+        self.assertEqual(ma.uuid.short_description, "UUID")
+
     def test_copyablefields_admin_fields_order(self):
         path = reverse("admin:test_project_project_add")
         self.client.get(path)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html)
- [x] I have manually tested the changes proposed in this pull request
- [x] I have written new test cases for new code created, or I have updated existing tests for modified code

## Description

Added a default `uuid()` method to `CopyableFieldsAdmin` that returns `obj.pk` with `short_description='UUID'`. This allows subclasses to use `copyable_fields = ('uuid',)` without defining their own `uuid` method when their model uses a UUID primary key.

Related to #328