### PR TITLE
[docs] Changelog bot docs: added retention-days

### DIFF
--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -604,6 +604,7 @@ approved by a maintainer and its title starts with ``[feature]``,
             with:
               name: changelog-metadata
               path: pr_number
+              retention-days: 1
 
 The runner workflow is triggered after the trigger workflow completes. It
 retrieves the PR metadata and calls the reusable changelog workflow.


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Updated the reusable GitHub utils documentation to add `retention-days: 1`
to the `changelog-metadata` artifact example.