### PR TITLE
[ci] Changelog bot: set retention to 1 day

### DIFF
--- a/.github/workflows/bot-changelog-trigger.yml
+++ b/.github/workflows/bot-changelog-trigger.yml
@@ -34,3 +34,4 @@ jobs:
         with:
           name: changelog-metadata
           path: pr_number
+          retention-days: 1


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

Adds retention-days: 1 to the uploaded changelog metadata artifact so temporary CI artifacts expire automatically.

