### PR TITLE
[fix] Fixed ValidatedModelSerializer: validation of PUT/PATCH & relationships #633

### DIFF
--- a/openwisp_utils/api/serializers.py
+++ b/openwisp_utils/api/serializers.py
@@ -1,8 +1,13 @@
+from copy import copy
+
 from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import models
+from django.db.models.fields.reverse_related import ForeignObjectRel
 
 try:
     from rest_framework import serializers
+    from rest_framework.exceptions import ValidationError as DRFValidationError
 except ImportError:  # pragma: nocover
     raise ImproperlyConfigured(
         "Django REST Framework is required to use "
@@ -20,15 +25,23 @@ class ValidatedModelSerializer(serializers.ModelSerializer):
         REST API.
         """
         instance = self.instance
-        # if instance is empty (eg: creation)
-        # simulate for validation purposes
         if not instance:
             Model = self.Meta.model
             instance = Model()
-            for key, value in data.items():
-                # avoid direct assignment for m2m (not allowed)
-                if not isinstance(Model._meta.get_field(key), models.ManyToManyField):
-                    setattr(instance, key, value)
-        # perform model validation
-        instance.full_clean(exclude=self.exclude_validation)
+        else:
+            instance = copy(instance)
+        for key, value in data.items():
+            Model = type(instance)
+            # avoid direct assignment for m2m (not allowed)
+            try:
+                field = Model._meta.get_field(key)
+            except Exception:
+                continue
+            if isinstance(field, (models.ManyToManyField, ForeignObjectRel)):
+                continue
+            setattr(instance, key, value)
+        try:
+            instance.full_clean(exclude=self.exclude_validation)
+        except DjangoValidationError as e:
+            raise DRFValidationError(detail=serializers.as_serializer_error(e))
         return data

--- a/openwisp_utils/api/serializers.py
+++ b/openwisp_utils/api/serializers.py
@@ -32,6 +32,7 @@ class ValidatedModelSerializer(serializers.ModelSerializer):
         if not instance:
             instance = Model()
         else:
+            # Validate incoming PUT/PATCH data without mutating the DB instance.
             instance = copy(instance)
         for key, value in data.items():
             # avoid direct assignment for m2m (not allowed)
@@ -40,6 +41,9 @@ class ValidatedModelSerializer(serializers.ModelSerializer):
             except FieldDoesNotExist:
                 continue
             if isinstance(field, (models.ManyToManyField, ForeignObjectRel)):
+                continue
+            # Skip nested relationships as we are only validating this model instance.
+            if field.is_relation and isinstance(value, (dict, list)):
                 continue
             setattr(instance, key, value)
         # perform model validation

--- a/openwisp_utils/api/serializers.py
+++ b/openwisp_utils/api/serializers.py
@@ -25,6 +25,8 @@ class ValidatedModelSerializer(serializers.ModelSerializer):
         REST API.
         """
         instance = self.instance
+        # if instance is empty (eg: creation)
+        # simulate for validation purposes
         if not instance:
             Model = self.Meta.model
             instance = Model()
@@ -40,6 +42,7 @@ class ValidatedModelSerializer(serializers.ModelSerializer):
             if isinstance(field, (models.ManyToManyField, ForeignObjectRel)):
                 continue
             setattr(instance, key, value)
+        # perform model validation
         try:
             instance.full_clean(exclude=self.exclude_validation)
         except DjangoValidationError as e:

--- a/openwisp_utils/api/serializers.py
+++ b/openwisp_utils/api/serializers.py
@@ -1,11 +1,12 @@
 from copy import copy
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db import models
-from django.db.models.fields.reverse_related import ForeignObjectRel
 
 try:
+    from django.core.exceptions import FieldDoesNotExist
+    from django.core.exceptions import ValidationError as DjangoValidationError
+    from django.db import models
+    from django.db.models.fields.reverse_related import ForeignObjectRel
     from rest_framework import serializers
     from rest_framework.exceptions import ValidationError as DRFValidationError
 except ImportError:  # pragma: nocover
@@ -25,19 +26,18 @@ class ValidatedModelSerializer(serializers.ModelSerializer):
         REST API.
         """
         instance = self.instance
+        Model = self.Meta.model
         # if instance is empty (eg: creation)
         # simulate for validation purposes
         if not instance:
-            Model = self.Meta.model
             instance = Model()
         else:
             instance = copy(instance)
         for key, value in data.items():
-            Model = type(instance)
             # avoid direct assignment for m2m (not allowed)
             try:
                 field = Model._meta.get_field(key)
-            except Exception:
+            except FieldDoesNotExist:
                 continue
             if isinstance(field, (models.ManyToManyField, ForeignObjectRel)):
                 continue

--- a/openwisp_utils/api/serializers.py
+++ b/openwisp_utils/api/serializers.py
@@ -1,12 +1,11 @@
 from copy import copy
 
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import models
+from django.db.models.fields.reverse_related import ForeignObjectRel
 
 try:
-    from django.core.exceptions import FieldDoesNotExist
-    from django.core.exceptions import ValidationError as DjangoValidationError
-    from django.db import models
-    from django.db.models.fields.reverse_related import ForeignObjectRel
     from rest_framework import serializers
     from rest_framework.exceptions import ValidationError as DRFValidationError
 except ImportError:  # pragma: nocover

--- a/tests/test_project/api/urls.py
+++ b/tests/test_project/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
 from . import views
 
@@ -7,5 +7,11 @@ urlpatterns = [
         r"^receive_project/(?P<pk>[^/\?]+)/$",
         views.receive_project,
         name="receive_project",
-    )
+    ),
+    path("shelves/", views.shelf_list_create_view, name="shelf_list"),
+    path(
+        "shelves/<uuid:pk>/",
+        views.shelf_retrieve_update_destroy_view,
+        name="shelf_detail",
+    ),
 ]

--- a/tests/test_project/api/views.py
+++ b/tests/test_project/api/views.py
@@ -1,8 +1,10 @@
 from django.http import JsonResponse
 from django.utils.translation import gettext_lazy as _
 from django.views import View
+from rest_framework import generics
+from test_project.serializers import ShelfSerializer
 
-from ..models import Project
+from ..models import Project, Shelf
 
 
 class ReceiveProjectView(View):
@@ -23,4 +25,16 @@ class ReceiveProjectView(View):
         return JsonResponse({"detail": _("ok"), "name": project.name}, status=200)
 
 
+class ShelfListCreateView(generics.ListCreateAPIView):
+    queryset = Shelf.objects.all()
+    serializer_class = ShelfSerializer
+
+
+class ShelfRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Shelf.objects.all()
+    serializer_class = ShelfSerializer
+
+
 receive_project = ReceiveProjectView.as_view()
+shelf_list_create_view = ShelfListCreateView.as_view()
+shelf_retrieve_update_destroy_view = ShelfRetrieveUpdateDestroyView.as_view()

--- a/tests/test_project/tests/test_api.py
+++ b/tests/test_project/tests/test_api.py
@@ -1,6 +1,9 @@
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from test_project.serializers import ShelfSerializer
 
 from ..models import Shelf
@@ -11,15 +14,9 @@ class TestApi(CreateMixin, TestCase):
     shelf_model = Shelf
     operator_permission_filter = [{"codename__endswith": "shelf"}]
 
-    def test_validator_pass(self):
-        s1 = self._create_shelf(name="shelf1")
-        serializer = ShelfSerializer(s1)
-        result = serializer.validate(s1)
-        self.assertIsInstance(result, Shelf)
-
     def test_validator_data_dict(self):
         s1 = self._create_shelf(name="shelf1")
-        data = s1.__dict__
+        data = s1.__dict__.copy()
         to_delete = [
             "_state",
             "id",
@@ -30,27 +27,26 @@ class TestApi(CreateMixin, TestCase):
         for key in to_delete:
             del data[key]
         data["writers"] = [1]
-        serializer = ShelfSerializer()
+        serializer = ShelfSerializer(instance=s1, data=data)
         data = serializer.validate(data)
 
     def test_validator_fail(self):
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(DjangoValidationError):
             self._create_shelf(name="Intentional_Test_Fail")
 
         s1 = self._create_shelf(name="shelf1")
-        s1.name = "Intentional_Test_Fail"
-        serializer = ShelfSerializer(s1)
-        with self.assertRaises(ValidationError):
-            serializer.validate(s1)
+        with self.assertRaises(DRFValidationError):
+            serializer = ShelfSerializer(instance=s1)
+            serializer.validate({"name": "Intentional_Test_Fail"})
 
     def test_exclude_validation(self):
         s1 = self._create_shelf(name="shelf1")
-        s1.books_type = "madeup"
-        serializer = ShelfSerializer(s1)
-        with self.assertRaises(ValidationError):
-            serializer.validate(s1)
+        with self.assertRaises(DRFValidationError):
+            serializer = ShelfSerializer(instance=s1)
+            serializer.validate({"books_type": "invalid"})
+        serializer = ShelfSerializer(instance=s1)
         serializer.exclude_validation = ["books_type"]
-        serializer.validate(s1)
+        serializer.validate({"books_type": "invalid"})
 
     def test_rest_framework_settings_override(self):
         drf_conf = getattr(settings, "REST_FRAMEWORK", {})
@@ -64,3 +60,117 @@ class TestApi(CreateMixin, TestCase):
                 "TEST": True,
             },
         )
+
+    def test_crud_shelf(self):
+        list_url = reverse("shelf_list")
+        with self.subTest("Create"):
+            response = self.client.post(
+                list_url,
+                {
+                    "name": "Fiction Shelf",
+                    "books_type": "FANTASY",
+                    "books_count": 3,
+                    "locked": False,
+                },
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(Shelf.objects.count(), 1)
+            pk = response.data["id"]
+
+        shelf = Shelf.objects.get(pk=pk)
+        detail_url = reverse("shelf_detail", args=[pk])
+        with self.subTest("List"):
+            response = self.client.get(list_url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data[0]["id"], pk)
+
+        with self.subTest("Retrieve"):
+            response = self.client.get(detail_url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["id"], pk)
+
+        with self.subTest("Update with PATCH"):
+            response = self.client.patch(
+                detail_url,
+                {"name": "Shelf - Updated"},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            shelf.refresh_from_db()
+            self.assertEqual(shelf.name, "Shelf - Updated")
+
+        with self.subTest("Update with PUT"):
+            payload = {
+                "name": "Shelf PUT Full",
+                "books_type": "FACTUAL",
+                "books_count": 5,
+                "locked": False,
+            }
+            response = self.client.put(
+                detail_url, payload, content_type="application/json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            shelf.refresh_from_db()
+            self.assertEqual(shelf.name, "Shelf PUT Full")
+
+        with self.subTest("Delete"):
+            response = self.client.delete(detail_url)
+            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+            self.assertEqual(Shelf.objects.count(), 0)
+
+    def test_model_validation_create_and_update(self):
+        list_url = reverse("shelf_list")
+        with self.subTest("Create (invalid)"):
+            response = self.client.post(
+                list_url, {"name": "Intentional_Test_Fail"}, format="json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        with self.subTest("Create (valid)"):
+            response = self.client.post(
+                list_url,
+                {
+                    "name": "Reference Shelf",
+                    "books_type": "FACTUAL",
+                    "books_count": 7,
+                    "locked": True,
+                },
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            pk = response.data["id"]
+
+        detail_url = reverse("shelf_detail", args=[pk])
+        with self.subTest("Update - PATCH (invalid)"):
+            response = self.client.patch(
+                detail_url,
+                {"name": "Intentional_Test_Fail"},
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        with self.subTest("Update - PUT (valid)"):
+            payload = {
+                "name": "Valid PUT Shelf",
+                "books_type": "FACTUAL",
+                "books_count": 10,
+                "locked": True,
+            }
+            response = self.client.put(
+                detail_url, payload, content_type="application/json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        with self.subTest("Update - PUT (invalid)"):
+            invalid_payload = {"books_count": 7}
+            response = self.client.put(
+                detail_url, invalid_payload, content_type="application/json"
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        with self.subTest("DB value unchanged after failed updates"):
+            shelf = Shelf.objects.get(pk=pk)
+            self.assertEqual(shelf.name, "Valid PUT Shelf")
+            self.assertEqual(shelf.books_count, 10)
+            self.assertEqual(shelf.locked, True)

--- a/tests/test_project/tests/test_api.py
+++ b/tests/test_project/tests/test_api.py
@@ -1,8 +1,9 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.test import TestCase
 from django.urls import reverse
-from rest_framework import status
+from rest_framework import serializers, status
 from rest_framework.exceptions import ValidationError as DRFValidationError
 from test_project.serializers import ShelfSerializer
 
@@ -47,6 +48,23 @@ class TestApi(CreateMixin, TestCase):
         serializer = ShelfSerializer(instance=s1)
         serializer.exclude_validation = ["books_type"]
         serializer.validate({"books_type": "invalid"})
+
+    def test_nested_relation_validation_data_is_not_assigned_directly(self):
+        class OwnerSerializer(serializers.ModelSerializer):
+            class Meta:
+                model = get_user_model()
+                fields = ["username"]
+
+        class NestedShelfSerializer(ShelfSerializer):
+            owner = OwnerSerializer()
+
+            class Meta(ShelfSerializer.Meta):
+                fields = ["name", "owner"]
+
+        s1 = self._create_shelf(name="shelf1")
+        data = {"owner": {"username": "alice"}}
+        serializer = NestedShelfSerializer(instance=s1)
+        self.assertEqual(serializer.validate(data), data)
 
     def test_rest_framework_settings_override(self):
         drf_conf = getattr(settings, "REST_FRAMEWORK", {})
@@ -163,11 +181,18 @@ class TestApi(CreateMixin, TestCase):
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         with self.subTest("Update - PUT (invalid)"):
-            invalid_payload = {"books_count": 7}
+            invalid_payload = {
+                "name": "Intentional_Test_Fail",
+                "books_type": "FACTUAL",
+                "books_count": 7,
+                "locked": True,
+            }
             response = self.client.put(
                 detail_url, invalid_payload, content_type="application/json"
             )
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertIn("Intentional_Test_Fail", str(response.data))
+            self.assertNotIn("This field is required", str(response.data))
 
         with self.subTest("DB value unchanged after failed updates"):
             shelf = Shelf.objects.get(pk=pk)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.



Closes #633.

## Description of Changes

`ValidatedModelSerializer.validate()` was not applying incoming data to
the instance before calling `full_clean()` during PUT/PATCH requests.
This caused model validation to run against stale DB values instead of
the updated data, allowing invalid updates to pass validation.

### Changes made:

- `openwisp_utils/api/serializers.py`:
- `tests/test_project/api/views.py`
- `tests/test_project/api/urls.py`: 
- `tests/test_project/tests/test_api.py`

## screenshots

<img width="751" height="272" alt="71" src="https://github.com/user-attachments/assets/32d31ddf-2fb7-4a0b-8500-50bc25d8f81f" />


