### PR TITLE
[chores] Changelog bot: prevented long body lines

### DIFF
--- a/.github/actions/bot-changelog-generator/generate_changelog.py
+++ b/.github/actions/bot-changelog-generator/generate_changelog.py
@@ -386,7 +386,10 @@ def build_prompt(
         "  from the user's perspective\n"
         "- Focus the body on user-visible behavior, fixes, configuration changes,\n"
         "  compatibility notes, or important implementation consequences\n"
-        f"- Wrap the body around {COMMIT_SUBJECT_LIMIT} characters per line\n"
+        f"- Every non-empty body line must be {COMMIT_SUBJECT_LIMIT} "
+        "characters or shorter\n"
+        "- Insert real newline characters to wrap long body sentences; do not "
+        "return one long paragraph\n"
         f"- Keep the body concise, using no more than "
         f"{COMMIT_BODY_MAX_NONEMPTY_LINES} non-empty lines after the title,\n"
         "  including any issue footer lines\n"
@@ -534,6 +537,14 @@ def get_changelog_bot_validation_errors(text: str) -> list[str]:
         errors.append("Commit message must include a body after a blank line.")
     elif not text.partition("\n\n")[2].strip():
         errors.append("Commit message body cannot be empty.")
+    else:
+        body = text.partition("\n\n")[2]
+        for line_number, line in enumerate(body.splitlines(), 1):
+            if line.strip() and len(line) > COMMIT_SUBJECT_LIMIT:
+                errors.append(
+                    f"Commit message body line {line_number} must be "
+                    f"{COMMIT_SUBJECT_LIMIT} characters or shorter."
+                )
     for pattern in suspicious_patterns:
         if re.search(pattern, text, re.IGNORECASE):
             errors.append(f"Commit message matched a blocked safety pattern: {pattern}")

--- a/.github/actions/bot-changelog-generator/test_generate_changelog.py
+++ b/.github/actions/bot-changelog-generator/test_generate_changelog.py
@@ -358,6 +358,11 @@ class TestBuildPrompt(unittest.TestCase):
             system_instruction,
         )
         self.assertIn(
+            f"Every non-empty body line must be {COMMIT_SUBJECT_LIMIT} "
+            "characters or shorter",
+            system_instruction,
+        )
+        self.assertIn(
             f"{COMMIT_BODY_MAX_NONEMPTY_LINES} non-empty lines after the title",
             system_instruction,
         )
@@ -650,6 +655,21 @@ class TestValidateChangelogOutput(unittest.TestCase):
         text = "[feature] Added new functionality"
         result = validate_changelog_output(text, "rst")
         self.assertFalse(result)
+
+    def test_invalid_body_line_too_long(self):
+        text = (
+            "[feature] Added new functionality\n\n"
+            "This body line is intentionally longer than seventy two characters "
+            "so the bot asks Gemini to wrap it."
+        )
+        errors = get_changelog_validation_errors(text, "rst")
+        self.assertEqual(
+            errors,
+            [
+                f"Commit message body line 1 must be {COMMIT_SUBJECT_LIMIT} "
+                "characters or shorter."
+            ],
+        )
 
     def test_invalid_empty_text(self):
         result = validate_changelog_output("", "rst")


### PR DESCRIPTION
Gemini can return squash commit descriptions as one long paragraph. That makes the changelog bot propose commit messages that are hard to reuse without manual wrapping.

Validate generated body lines and make the prompt state the hard line-length rule explicitly so Gemini gets actionable retry feedback.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

As it's a small patch, I did not open an issue to reduce noise.