### PR TITLE
[chores] Releaser: bump docker-openwisp via make bump #688

### DIFF
--- a/openwisp_utils/releaser/config.py
+++ b/openwisp_utils/releaser/config.py
@@ -103,32 +103,33 @@ def _handle_npm_version(config):
 
 
 def _handle_docker_version(config):
-    """Handles version detection for Docker packages."""
-    if not os.path.exists("Makefile"):
+    """Handles version detection for docker-openwisp.
+
+    docker-openwisp stores its canonical release version in
+    images/common/openwisp/VERSION and bumps it via ``make bump``.
+    """
+    version_path = os.path.join("images", "common", "openwisp", "VERSION")
+    if not os.path.exists(version_path):
         return
-    with open("Makefile", "r") as f:
-        content = f.read()
-        version_match = re.search(
-            r"^OPENWISP_VERSION\s*=\s*([^\s]+)", content, re.MULTILINE
-        )
-        if not version_match:
-            return
-        config["version_path"] = "Makefile"
-        try:
-            version_str = version_match.group(1)
-            parts = version_str.split(".")
-            if len(parts) != 3:
-                raise ValueError(
-                    f"Version '{version_str}' does not have expected 3 parts (X.Y.Z)"
-                )
-            config["CURRENT_VERSION"] = [
-                int(parts[0]),
-                int(parts[1]),
-                int(parts[2]),
-                "final",
-            ]
-        except (ValueError, SyntaxError):
-            config["CURRENT_VERSION"] = None
+    with open(version_path, "r") as f:
+        version_str = f.read().strip()
+    if not version_str:
+        return
+    config["version_path"] = version_path
+    try:
+        parts = version_str.split(".")
+        if len(parts) != 3:
+            raise ValueError(
+                f"Version '{version_str}' does not have expected 3 parts (X.Y.Z)"
+            )
+        config["CURRENT_VERSION"] = [
+            int(parts[0]),
+            int(parts[1]),
+            int(parts[2]),
+            "final",
+        ]
+    except (ValueError, SyntaxError):
+        config["CURRENT_VERSION"] = None
 
 
 def _handle_ansible_version(config):

--- a/openwisp_utils/releaser/config.py
+++ b/openwisp_utils/releaser/config.py
@@ -111,11 +111,13 @@ def _handle_docker_version(config):
     version_path = os.path.join("images", "common", "openwisp", "VERSION")
     if not os.path.exists(version_path):
         return
+    # Record the path even if the file is empty or malformed, so bump_version
+    # can still recover via ``make bump`` after a manual version entry.
+    config["version_path"] = version_path
     with open(version_path, "r") as f:
         version_str = f.read().strip()
     if not version_str:
         return
-    config["version_path"] = version_path
     try:
         parts = version_str.split(".")
         if len(parts) != 3:

--- a/openwisp_utils/releaser/tests/conftest.py
+++ b/openwisp_utils/releaser/tests/conftest.py
@@ -79,22 +79,6 @@ def create_package_json():
     return _create_package_json
 
 
-def _create_makefile(path: Path, version="1.2.3"):
-    """Helper to create a Makefile for docker projects."""
-    makefile_content = f"""OPENWISP_VERSION = {version}
-DOCKER_IMAGE = openwisp/test
-
-build:
-\tdocker build -t $(DOCKER_IMAGE):$(OPENWISP_VERSION) .
-"""
-    (path / "Makefile").write_text(makefile_content)
-
-
-@pytest.fixture
-def create_makefile():
-    return _create_makefile
-
-
 def _create_docker_compose(path: Path):
     """Helper to create a docker-compose.yml file."""
     (path / "docker-compose.yml").write_text(
@@ -105,6 +89,18 @@ def _create_docker_compose(path: Path):
 @pytest.fixture
 def create_docker_compose():
     return _create_docker_compose
+
+
+def _create_docker_version_file(path: Path, version="1.2.3"):
+    """Helper to create images/common/openwisp/VERSION for docker-openwisp."""
+    version_dir = path / "images" / "common" / "openwisp"
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / "VERSION").write_text(f"{version}\n")
+
+
+@pytest.fixture
+def create_docker_version_file():
+    return _create_docker_version_file
 
 
 def _create_ansible_lint(path: Path):

--- a/openwisp_utils/releaser/tests/test_config.py
+++ b/openwisp_utils/releaser/tests/test_config.py
@@ -268,6 +268,26 @@ def test_docker_package_without_version_file(
     assert config["CURRENT_VERSION"] is None
 
 
+def test_docker_package_empty_version_file(
+    project_dir,
+    create_docker_compose,
+    create_docker_version_file,
+    create_changelog,
+    init_git_repo,
+):
+    """Tests docker package with an empty canonical VERSION file."""
+    create_docker_compose(project_dir)
+    create_docker_version_file(project_dir, version="")
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] == "docker"
+    # version_path is recorded so make bump can still recover after a
+    # manual version entry, even though the current version is unknown.
+    assert config["version_path"] == DOCKER_VERSION_PATH
+    assert config["CURRENT_VERSION"] is None
+
+
 def test_docker_package_invalid_version(
     project_dir,
     create_docker_compose,

--- a/openwisp_utils/releaser/tests/test_config.py
+++ b/openwisp_utils/releaser/tests/test_config.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from openwisp_utils.releaser.config import detect_changelog_style, load_config
 
@@ -231,25 +233,32 @@ def test_npm_package_invalid_version(
     assert config["CURRENT_VERSION"] is None
 
 
-# Docker Package Tests
+# Docker (docker-openwisp) Package Tests
+DOCKER_VERSION_PATH = os.path.join("images", "common", "openwisp", "VERSION")
+
+
 def test_docker_package_detection(
-    project_dir, create_docker_compose, create_makefile, create_changelog, init_git_repo
+    project_dir,
+    create_docker_compose,
+    create_docker_version_file,
+    create_changelog,
+    init_git_repo,
 ):
-    """Tests that docker package type is detected when docker-compose.yml exists."""
+    """Tests that docker type is detected when docker-compose.yml exists."""
     create_docker_compose(project_dir)
-    create_makefile(project_dir, version="1.2.3")
+    create_docker_version_file(project_dir, version="1.2.3")
     create_changelog(project_dir)
     init_git_repo(project_dir)
     config = load_config()
     assert config["package_type"] == "docker"
-    assert config["version_path"] == "Makefile"
+    assert config["version_path"] == DOCKER_VERSION_PATH
     assert config["CURRENT_VERSION"] == [1, 2, 3, "final"]
 
 
-def test_docker_package_without_makefile(
+def test_docker_package_without_version_file(
     project_dir, create_docker_compose, create_changelog, init_git_repo
 ):
-    """Tests docker package without Makefile - version should be None."""
+    """Tests docker package without the canonical VERSION file."""
     create_docker_compose(project_dir)
     create_changelog(project_dir)
     init_git_repo(project_dir)
@@ -260,18 +269,20 @@ def test_docker_package_without_makefile(
 
 
 def test_docker_package_invalid_version(
-    project_dir, create_docker_compose, create_changelog, init_git_repo
+    project_dir,
+    create_docker_compose,
+    create_docker_version_file,
+    create_changelog,
+    init_git_repo,
 ):
-    """Tests docker package with invalid version in Makefile gracefully."""
+    """Tests docker package with an invalid version in the VERSION file."""
     create_docker_compose(project_dir)
-    (project_dir / "Makefile").write_text(
-        "OPENWISP_VERSION = 1.2\n"
-    )  # Invalid: only 2 parts
+    create_docker_version_file(project_dir, version="1.2")  # Invalid: only 2 parts
     create_changelog(project_dir)
     init_git_repo(project_dir)
     config = load_config()
     assert config["package_type"] == "docker"
-    assert config["version_path"] == "Makefile"
+    assert config["version_path"] == DOCKER_VERSION_PATH
     assert config["CURRENT_VERSION"] is None
 
 

--- a/openwisp_utils/releaser/tests/test_version_bumping.py
+++ b/openwisp_utils/releaser/tests/test_version_bumping.py
@@ -1,3 +1,4 @@
+import subprocess
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -244,8 +245,51 @@ def test_bump_version_docker():
 
     assert result is True
     mock_run.assert_called_once_with(
-        ["make", "bump", "VERSION=1.2.4"], check=True, capture_output=True
+        ["make", "bump", "VERSION=1.2.4"],
+        check=True,
+        capture_output=True,
+        text=True,
     )
+    # make bump writes the file itself; bump_version must not write again.
+    m_open().write.assert_not_called()
+
+
+def test_bump_version_docker_make_failure():
+    """A failing 'make bump' surfaces Make's output in the raised error."""
+    config = {
+        "package_type": "docker",
+        "version_path": "images/common/openwisp/VERSION",
+        "CURRENT_VERSION": [1, 2, 3, "final"],
+    }
+    error = subprocess.CalledProcessError(
+        returncode=2, cmd=["make", "bump", "VERSION=1.2.4"]
+    )
+    error.stdout = "building...\n"
+    error.stderr = "ERROR: boom\n"
+    m_open = mock_open(read_data="1.2.3\n")
+    with (
+        patch("openwisp_utils.releaser.version.subprocess.run", side_effect=error),
+        patch("builtins.open", m_open),
+    ):
+        with pytest.raises(RuntimeError, match="ERROR: boom"):
+            bump_version(config, "1.2.4")
+
+
+def test_bump_version_docker_unchanged_file():
+    """A 'make bump' that exits 0 but leaves VERSION stale must fail loudly."""
+    config = {
+        "package_type": "docker",
+        "version_path": "images/common/openwisp/VERSION",
+        "CURRENT_VERSION": [1, 2, 3, "final"],
+    }
+    # subprocess succeeds, but the file still holds the old version.
+    m_open = mock_open(read_data="1.2.3\n")
+    with (
+        patch("openwisp_utils.releaser.version.subprocess.run"),
+        patch("builtins.open", m_open),
+    ):
+        with pytest.raises(RuntimeError, match="contains '1.2.3'"):
+            bump_version(config, "1.2.4")
 
 
 # Ansible Package Version Tests

--- a/openwisp_utils/releaser/tests/test_version_bumping.py
+++ b/openwisp_utils/releaser/tests/test_version_bumping.py
@@ -275,6 +275,25 @@ def test_bump_version_docker_make_failure():
             bump_version(config, "1.2.4")
 
 
+def test_bump_version_docker_make_missing():
+    """A missing 'make' executable raises a diagnosable release error."""
+    config = {
+        "package_type": "docker",
+        "version_path": "images/common/openwisp/VERSION",
+        "CURRENT_VERSION": [1, 2, 3, "final"],
+    }
+    m_open = mock_open(read_data="1.2.3\n")
+    with (
+        patch(
+            "openwisp_utils.releaser.version.subprocess.run",
+            side_effect=FileNotFoundError(),
+        ),
+        patch("builtins.open", m_open),
+    ):
+        with pytest.raises(RuntimeError, match="`make` is required"):
+            bump_version(config, "1.2.4")
+
+
 def test_bump_version_docker_unchanged_file():
     """A 'make bump' that exits 0 but leaves VERSION stale must fail loudly."""
     config = {

--- a/openwisp_utils/releaser/tests/test_version_bumping.py
+++ b/openwisp_utils/releaser/tests/test_version_bumping.py
@@ -98,8 +98,9 @@ def test_get_current_version_short_tuple():
 def test_bump_version_no_tuple_found(mock_config):
     """Tests RuntimeError during version bumping if VERSION is not found."""
     mock_config["package_type"] = "python"
-    with patch("os.path.exists", return_value=True), patch(
-        "builtins.open", mock_open(read_data="NO_VERSION_HERE")
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("builtins.open", mock_open(read_data="NO_VERSION_HERE")),
     ):
         with pytest.raises(RuntimeError, match="Failed to find and bump VERSION"):
             bump_version(mock_config, "1.2.1")
@@ -214,12 +215,12 @@ def test_bump_version_npm():
     assert '"version": "1.2.4"' in written_content
 
 
-# Docker Package Version Tests
+# Docker (docker-openwisp) Package Version Tests
 def test_get_current_version_docker():
-    """Tests getting current version from docker Makefile."""
+    """Tests getting current version from the docker-openwisp VERSION file."""
     config = {
         "package_type": "docker",
-        "version_path": "Makefile",
+        "version_path": "images/common/openwisp/VERSION",
         "CURRENT_VERSION": [1, 2, 3, "final"],
     }
     version, version_type = get_current_version(config)
@@ -228,20 +229,23 @@ def test_get_current_version_docker():
 
 
 def test_bump_version_docker():
-    """Tests bumping version for docker packages in Makefile."""
+    """Tests that docker-openwisp is bumped via the canonical 'make bump'."""
     config = {
         "package_type": "docker",
-        "version_path": "Makefile",
+        "version_path": "images/common/openwisp/VERSION",
         "CURRENT_VERSION": [1, 2, 3, "final"],
     }
-    makefile_content = "OPENWISP_VERSION = 1.2.3\nDOCKER_IMAGE = openwisp/test\n"
-    m_open = mock_open(read_data=makefile_content)
-    with patch("os.path.exists", return_value=True), patch("builtins.open", m_open):
+    m_open = mock_open(read_data="1.2.4\n")
+    with (
+        patch("openwisp_utils.releaser.version.subprocess.run") as mock_run,
+        patch("builtins.open", m_open),
+    ):
         result = bump_version(config, "1.2.4")
 
     assert result is True
-    written_content = m_open().write.call_args[0][0]
-    assert "OPENWISP_VERSION = 1.2.4" in written_content
+    mock_run.assert_called_once_with(
+        ["make", "bump", "VERSION=1.2.4"], check=True, capture_output=True
+    )
 
 
 # Ansible Package Version Tests

--- a/openwisp_utils/releaser/version.py
+++ b/openwisp_utils/releaser/version.py
@@ -1,5 +1,6 @@
 import json
 import re
+import subprocess
 import sys
 
 import questionary
@@ -64,14 +65,20 @@ def _bump_npm_version(content, new_version, version_path):
 
 
 def _bump_docker_version(content, new_version, version_path):
-    """Handles version bumping for Docker packages."""
-    return _bump_with_regex(
-        content,
-        r"^OPENWISP_VERSION\s*=\s*[^\s]+",
-        f"OPENWISP_VERSION = {new_version}",
-        version_path,
-        "OPENWISP_VERSION",
+    """Handles version bumping for docker-openwisp.
+
+    Delegates to docker-openwisp's canonical ``make bump`` target so the
+    releaser does not need to know how the version is stored on disk.
+    """
+    subprocess.run(
+        ["make", "bump", f"VERSION={new_version}"],
+        check=True,
+        capture_output=True,
     )
+    # ``make bump`` already wrote the canonical VERSION file; return its
+    # content so the caller writes back the same value.
+    with open(version_path, "r") as f:
+        return f.read()
 
 
 def _bump_ansible_version(content, new_version, version_path):

--- a/openwisp_utils/releaser/version.py
+++ b/openwisp_utils/releaser/version.py
@@ -69,16 +69,31 @@ def _bump_docker_version(content, new_version, version_path):
 
     Delegates to docker-openwisp's canonical ``make bump`` target so the
     releaser does not need to know how the version is stored on disk.
+    Verifies the canonical VERSION file was updated, then returns ``None``
+    so the caller skips the write-back (``make bump`` already wrote it).
     """
-    subprocess.run(
-        ["make", "bump", f"VERSION={new_version}"],
-        check=True,
-        capture_output=True,
-    )
-    # ``make bump`` already wrote the canonical VERSION file; return its
-    # content so the caller writes back the same value.
+    try:
+        subprocess.run(
+            ["make", "bump", f"VERSION={new_version}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        # Surface Make's output so the failure is diagnosable.
+        raise RuntimeError(
+            f"`make bump VERSION={new_version}` failed:\n{e.stdout}{e.stderr}"
+        ) from e
+    # A zero-exit ``make bump`` does not guarantee the file changed; verify it
+    # so a no-op target cannot silently produce a stale release.
     with open(version_path, "r") as f:
-        return f.read()
+        bumped_version = f.read().strip()
+    if bumped_version != new_version:
+        raise RuntimeError(
+            f"`make bump VERSION={new_version}` completed but {version_path} "
+            f"contains {bumped_version!r}."
+        )
+    return None
 
 
 def _bump_ansible_version(content, new_version, version_path):
@@ -127,8 +142,11 @@ def bump_version(config, new_version):
     if not handler:
         raise RuntimeError(f"Unknown package type: {package_type}")
     new_content = handler(content, new_version, version_path)
-    with open(version_path, "w") as f:
-        f.write(new_content)
+    # A handler may return None to signal it already wrote the file itself
+    # (e.g. docker-openwisp delegates the write to ``make bump``).
+    if new_content is not None:
+        with open(version_path, "w") as f:
+            f.write(new_content)
     return True
 
 

--- a/openwisp_utils/releaser/version.py
+++ b/openwisp_utils/releaser/version.py
@@ -84,6 +84,10 @@ def _bump_docker_version(content, new_version, version_path):
         raise RuntimeError(
             f"`make bump VERSION={new_version}` failed:\n{e.stdout}{e.stderr}"
         ) from e
+    except FileNotFoundError as e:
+        raise RuntimeError(
+            "`make` is required to bump docker-openwisp but was not found on PATH."
+        ) from e
     # A zero-exit ``make bump`` does not guarantee the file changed; verify it
     # so a no-op target cannot silently produce a stale release.
     with open(version_path, "r") as f:


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #688
Related to https://github.com/openwisp/docker-openwisp/issues/570.

## Description of Changes

The releaser's docker package type was written for docker-openwisp's old layout, reading and rewriting `OPENWISP_VERSION` in the Makefile. docker-openwisp now stores its canonical release version in `images/common/openwisp/VERSION` and bumps it via `make bump VERSION=<version>`.

`OPENWISP_VERSION` is now only an image tag, so the old logic was stale.

Version detection now reads `images/common/openwisp/VERSION` and the bump delegates to "make bump", so the releaser no longer needs to know how the version is stored on disk. Detection of the docker type still relies on docker-compose.yml.