### PR TITLE
[qa] Exclude node_modules from RST check

### DIFF
--- a/docs/developer/qa-checks.rst
+++ b/docs/developer/qa-checks.rst
@@ -200,3 +200,5 @@ app name that should be passed to ``./manage.py makemigrations``, e.g.:
 
 Checks the syntax of all ReStructuredText files to ensure they can be
 published on Pypi or using python-sphinx.
+
+The ``node_modules`` directory is excluded by default.

--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -118,7 +118,7 @@ runflake8() {
 }
 
 runrstcheck() {
-  cmd="docstrfmt --no-docstring-trailing-line -i -c -l 74 -s =-~+^\"\'.: ."
+  cmd="docstrfmt --no-docstring-trailing-line -i -c -l 74 -s =-~+^\"\'.: --extend-exclude node_modules ."
   $($cmd --quiet) &&
     echo "SUCCESS: ReStructuredText check successful!" ||
     {

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import tempfile
 from os import path
 from unittest.mock import patch
 
@@ -247,3 +249,44 @@ class TestQa(TestCase):
                 except (SystemExit, Exception) as e:
                     msg = "Check failed:\n\n{}\n\nOutput:{}".format(option[-1], e)
                     self.fail(msg)
+
+    def test_checkrst_excludes_node_modules(self):
+        script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))
+        script_path = path.join(script_path, "openwisp-qa-check")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_dir = path.join(temp_dir, "bin")
+            os.mkdir(bin_dir)
+            args_path = path.join(temp_dir, "docstrfmt-args.txt")
+            docstrfmt_path = path.join(bin_dir, "docstrfmt")
+            with open(docstrfmt_path, "w") as f:
+                f.write(
+                    "#!/bin/sh\n"
+                    'for arg in "$@"; do\n'
+                    '    printf "%s\\n" "$arg" >> "$DOCSTRFMT_ARGS"\n'
+                    "done\n"
+                )
+            os.chmod(docstrfmt_path, 0o755)
+            env = os.environ.copy()
+            env["DOCSTRFMT_ARGS"] = args_path
+            env["PATH"] = f'{bin_dir}:{env["PATH"]}'
+            result = subprocess.run(
+                [
+                    script_path,
+                    "--skip-checkmigrations",
+                    "--skip-checkendline",
+                    "--skip-flake8",
+                    "--skip-isort",
+                    "--skip-black",
+                    "--skip-checkcommit",
+                    "--skip-checkmakemigrations",
+                ],
+                cwd=temp_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(args_path) as f:
+                args = f.read().splitlines()
+            self.assertIn("--extend-exclude", args)
+            self.assertIn("node_modules", args)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

No existing issue.

## Description of Changes

This change excludes ``node_modules`` from the ``checkrst`` QA check by default. It avoids projects with frontend dependencies having to skip ``checkrst`` and run ``docstrfmt`` separately just to ignore ReStructuredText files vendored by npm packages.

The regression test verifies that ``openwisp-qa-check`` passes ``--extend-exclude node_modules`` to ``docstrfmt`` when running ``checkrst``.

## Screenshot

Not applicable.
