### PR TITLE
[change] SeleniumTestMixin now retries up to 2 successful runs

### DIFF
--- a/docs/developer/test-utilities.rst
+++ b/docs/developer/test-utilities.rst
@@ -180,8 +180,10 @@ methods that must be used across all OpenWISP modules based on Django to
 enforce best practices and avoid flaky tests.
 
 It includes a built-in retry mechanism that can automatically repeat
-failing tests to identify transient (flaky) failures. You can customize
-this behavior using the following class attributes:
+failing tests to mitigate transient (flaky) failures. When a Selenium test
+fails, it must pass 2 successful retry runs by default before it is
+considered successful. You can customize this behavior using the following
+class attributes:
 
 - ``retry_max``: The maximum number of times to retry a failing test.
   Defaults to ``5``.

--- a/docs/developer/test-utilities.rst
+++ b/docs/developer/test-utilities.rst
@@ -187,9 +187,11 @@ this behavior using the following class attributes:
   Defaults to ``5``.
 - ``retry_delay``: The number of seconds to wait between retries. Defaults
   to ``0``.
-- ``retry_threshold``: The minimum ratio of successful retries required
-  for the test to be considered as passed. If the success ratio falls
-  below this threshold, the test is marked as failed. Defaults to ``0.8``.
+- ``retry_successes_required``: The number of successful retries required
+  after a failure for the test to be considered as passed. Defaults to
+  ``2``.
+- ``retry_threshold``: Deprecated. Existing test suites can still use it
+  to require a minimum ratio of successful retries.
 
 **Example usage:**
 
@@ -202,7 +204,7 @@ this behavior using the following class attributes:
     class MySeleniumTest(SeleniumTestMixin, StaticLiveServerTestCase):
         retry_max = 10
         retry_delay = 0
-        retry_threshold = 0.9
+        retry_successes_required = 3
 
         def test_something(self):
             self.open("/some-url/")

--- a/openwisp_utils/tests/selenium.py
+++ b/openwisp_utils/tests/selenium.py
@@ -1,5 +1,6 @@
 import os
 import time
+from math import ceil
 
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
@@ -22,11 +23,15 @@ class SeleniumTestMixin:
 
     retry_max = 5
     retry_delay = 0
-    retry_threshold = 0.8
+    retry_successes_required = 2
+    retry_threshold = None
+
+    def _get_retry_successes_required(self):
+        if self.retry_threshold is not None:
+            return ceil(self.retry_max * self.retry_threshold)
+        return self.retry_successes_required
 
     def _print_retry_message(self, test_name, attempt):
-        if attempt == 0:
-            return
         print("-" * 80)
         print(f'[Retry] Retrying "{test_name}", attempt {attempt}/{self.retry_max}. ')
         print("-" * 80)
@@ -42,6 +47,7 @@ class SeleniumTestMixin:
         test_name = self.id()
         success_count = 0
         failed_result = None
+        retry_successes_required = self._get_retry_successes_required()
         # Manually call startTest to ensure TimeLoggingTestResult can
         # measure the execution time for the test.
         original_result.startTest(self)
@@ -71,16 +77,19 @@ class SeleniumTestMixin:
                     return
                 else:
                     success_count += 1
+                    if success_count >= retry_successes_required:
+                        original_result.addSuccess(self)
+                        return
             else:
                 failed_result = result
-            self._print_retry_message(test_name, attempt)
-            if self.retry_delay:
-                time.sleep(self.retry_delay)
+            if attempt < self.retry_max:
+                self._print_retry_message(test_name, attempt + 1)
+                if self.retry_delay:
+                    time.sleep(self.retry_delay)
 
-        if success_count / self.retry_max < self.retry_threshold:
-            # If the success rate of retries is below the threshold then,
-            # copy errors and failures from the last failed result to the
-            # original result.
+        if success_count < retry_successes_required:
+            # If there are too few successful retries, copy the last failed
+            # result to the original result.
             original_result.failures = failed_result.failures
             original_result.errors = failed_result.errors
             if hasattr(original_result, "events"):

--- a/tests/test_project/tests/test_selenium_skip.py
+++ b/tests/test_project/tests/test_selenium_skip.py
@@ -5,6 +5,21 @@ from django.test.runner import RemoteTestRunner
 from openwisp_utils.tests.selenium import SeleniumTestMixin
 
 
+class SeleniumRetryTestMixin(SeleniumTestMixin, SimpleTestCase):
+    retry_delay = 0
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+
 class TestSeleniumMixinSkipHandling(SimpleTestCase):
     def _run_skipped_standard_test(self):
         class SkippedSeleniumTest(SeleniumTestMixin, SimpleTestCase):
@@ -67,3 +82,56 @@ class TestSeleniumMixinSkipHandling(SimpleTestCase):
                 ("stopTest", 1),
             ],
         )
+
+
+class TestSeleniumMixinRetryHandling(SimpleTestCase):
+    def test_setup_and_call_stops_after_required_successful_retries(self):
+        class FlakySeleniumTest(SeleniumRetryTestMixin):
+            retry_max = 5
+
+            def test_flaky(self):
+                if not hasattr(self, "calls"):
+                    self.calls = 0
+                self.calls += 1
+                if self.calls == 1:
+                    self.fail("failing first call")
+
+        test = FlakySeleniumTest("test_flaky")
+        result = TestResult()
+        test._setup_and_call(result)
+        self.assertTrue(result.wasSuccessful())
+        self.assertEqual(test.calls, 3)
+
+    def test_setup_and_call_allows_non_consecutive_successful_retries(self):
+        class FlakySeleniumTest(SeleniumRetryTestMixin):
+            retry_max = 5
+
+            def test_flaky(self):
+                if not hasattr(self, "calls"):
+                    self.calls = 0
+                self.calls += 1
+                if self.calls in [1, 3]:
+                    self.fail("intermittent failure")
+
+        test = FlakySeleniumTest("test_flaky")
+        result = TestResult()
+        test._setup_and_call(result)
+        self.assertTrue(result.wasSuccessful())
+        self.assertEqual(test.calls, 4)
+
+    def test_setup_and_call_fails_when_retry_successes_are_insufficient(self):
+        class FlakySeleniumTest(SeleniumRetryTestMixin):
+            retry_max = 5
+
+            def test_flaky(self):
+                if not hasattr(self, "calls"):
+                    self.calls = 0
+                self.calls += 1
+                if self.calls != 2:
+                    self.fail("too flaky")
+
+        test = FlakySeleniumTest("test_flaky")
+        result = TestResult()
+        test._setup_and_call(result)
+        self.assertFalse(result.wasSuccessful())
+        self.assertEqual(test.calls, 6)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

No existing issue.

## Description of Changes

This change updates ``SeleniumTestMixin`` retry handling so flaky tests do not keep running every configured retry once they already proved stable enough to pass.

Previously, a test that failed once would always run all retries and needed to pass the configured success ratio. With the default settings, that meant up to five extra executions, even when two retries passed. That made flaky Selenium failures take longer to complete and made local debugging more frustrating.

The new default requires two successful retries after an initial failure. Once that requirement is met, the test stops and is marked successful. Tests that cannot reach the required successful retries within the retry budget still fail, so very flaky tests are still caught.

Retry log messages now print before the next retry attempt, which makes failure output easier to follow. The previous ``retry_threshold`` setting is still supported for existing test suites, but ``retry_successes_required`` is now the documented option.

## Screenshot

Not applicable.
