### PR TITLE
[fix:qa] Excluded node_modules and hidden directories from ReStructuredText check

### DIFF
--- a/docs/developer/qa-checks.rst
+++ b/docs/developer/qa-checks.rst
@@ -201,4 +201,5 @@ app name that should be passed to ``./manage.py makemigrations``, e.g.:
 Checks the syntax of all ReStructuredText files to ensure they can be
 published on Pypi or using python-sphinx.
 
-The ``node_modules`` directory is excluded by default.
+Hidden directories and the ``node_modules`` directory are excluded by
+default.

--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -118,14 +118,19 @@ runflake8() {
 }
 
 runrstcheck() {
-  cmd="docstrfmt --no-docstring-trailing-line -i -c -l 74 -s =-~+^\"\'.: --extend-exclude node_modules ."
-  $($cmd --quiet) &&
-    echo "SUCCESS: ReStructuredText check successful!" ||
-    {
+  local files=()
+  mapfile -t files < <(find . -path "*/.*" -prune -o -path "*/node_modules/*" -prune \
+    -o -type f \( -name "*.py" -o -name "*.rst" \) -print | sort)
+  if [ ${#files[@]} -gt 0 ]; then
+    local cmd=(docstrfmt --no-docstring-trailing-line -i -c -l 74 -s "=-~+^\"'.:" "${files[@]}")
+    "${cmd[@]}" --quiet || {
       echoerr "ERROR: ReStructuredText check failed!"
-      $($cmd)
+      "${cmd[@]}"
       FAILURE=1
+      return
     }
+  fi
+  echo "SUCCESS: ReStructuredText check successful!"
 }
 
 runisort() {

--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -121,13 +121,15 @@ runrstcheck() {
   local files=()
   # Build the file list manually so docstrfmt never sees node_modules or
   # hidden directories; its built-in exclude matching misses deeply nested paths.
-  mapfile -t files < <(find . -path "*/.*" -prune -o -path "*/node_modules/*" -prune \
-    -o -type f \( -name "*.py" -o -name "*.rst" \) -print | sort)
+  while IFS= read -r -d '' file; do
+    files+=("$file")
+  done < <(find . -path "*/.*" -prune -o -path "*/node_modules/*" -prune \
+    -o -type f \( -name "*.py" -o -name "*.rst" \) -print0)
   if [ ${#files[@]} -gt 0 ]; then
-    local cmd=(docstrfmt --no-docstring-trailing-line -i -c -l 74 -s "=-~+^\"'.:" "${files[@]}")
-    "${cmd[@]}" --quiet || {
+    local cmd=(docstrfmt --no-docstring-trailing-line -i -c -l 74 -s "=-~+^\"'.:")
+    "${cmd[@]}" --quiet "${files[@]}" || {
       echoerr "ERROR: ReStructuredText check failed!"
-      "${cmd[@]}"
+      "${cmd[@]}" "${files[@]}"
       FAILURE=1
       return
     }

--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -119,6 +119,8 @@ runflake8() {
 
 runrstcheck() {
   local files=()
+  # Build the file list manually so docstrfmt never sees node_modules or
+  # hidden directories; its built-in exclude matching misses deeply nested paths.
   mapfile -t files < <(find . -path "*/.*" -prune -o -path "*/node_modules/*" -prune \
     -o -type f \( -name "*.py" -o -name "*.rst" \) -print | sort)
   if [ ${#files[@]} -gt 0 ]; then

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -266,6 +266,26 @@ class TestQa(TestCase):
                     "done\n"
                 )
             os.chmod(docstrfmt_path, 0o755)
+            # Create a normal Python file
+            work_file = path.join(temp_dir, "work.py")
+            with open(work_file, "w") as f:
+                f.write("x = 1\n")
+            spaced_file = path.join(temp_dir, "work with spaces.rst")
+            with open(spaced_file, "w") as f:
+                f.write("Test\n====\n")
+            # Create files inside node_modules (should be excluded)
+            node_module_py = path.join(temp_dir, "node_modules", "pkg", "file.py")
+            os.makedirs(path.dirname(node_module_py))
+            with open(node_module_py, "w") as f:
+                f.write("y = 2\n")
+            node_module_rst = path.join(temp_dir, "node_modules", "other", "doc.rst")
+            os.makedirs(path.dirname(node_module_rst))
+            with open(node_module_rst, "w") as f:
+                f.write("Test\n====\n")
+            hidden_py = path.join(temp_dir, ".github", "actions", "script.py")
+            os.makedirs(path.dirname(hidden_py))
+            with open(hidden_py, "w") as f:
+                f.write("z = 3\n")
             env = os.environ.copy()
             env["DOCSTRFMT_ARGS"] = args_path
             env["PATH"] = f'{bin_dir}:{env["PATH"]}'
@@ -286,7 +306,14 @@ class TestQa(TestCase):
                 text=True,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.count("SUCCESS: ReStructuredText check successful!"),
+                1,
+            )
             with open(args_path) as f:
                 args = f.read().splitlines()
-            self.assertIn("--extend-exclude", args)
-            self.assertIn("node_modules", args)
+            self.assertIn("./work.py", args)
+            self.assertIn("./work with spaces.rst", args)
+            self.assertNotIn("./node_modules/pkg/file.py", args)
+            self.assertNotIn("./node_modules/other/doc.rst", args)
+            self.assertNotIn("./.github/actions/script.py", args)

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -312,8 +312,11 @@ class TestQa(TestCase):
             )
             with open(args_path) as f:
                 args = f.read().splitlines()
+            quiet_index = args.index("--quiet")
             self.assertIn("./work.py", args)
             self.assertIn("./work with spaces.rst", args)
+            self.assertLess(quiet_index, args.index("./work.py"))
+            self.assertLess(quiet_index, args.index("./work with spaces.rst"))
             self.assertNotIn("./node_modules/pkg/file.py", args)
             self.assertNotIn("./node_modules/other/doc.rst", args)
             self.assertNotIn("./.github/actions/script.py", args)


### PR DESCRIPTION
Fixes the RST QA check so files inside `node_modules/` are skipped reliably.

The previous `--extend-exclude node_modules` approach did not skip deeply nested files, so this uses `find -prune` before calling `docstrfmt`.

The regression test also checks that hidden directories are not included and that the success message is printed once.
