### PR TITLE
[change] Changelog bot: mitigate quota exhaustion and improved consistency

### DIFF
--- a/.github/actions/bot-changelog-generator/action.yml
+++ b/.github/actions/bot-changelog-generator/action.yml
@@ -15,6 +15,10 @@ inputs:
   repo-name:
     description: "Repository name in format owner/repo"
     required: true
+  gemini-model:
+    description: "Gemini model to use (empty falls back to gemini-2.5-flash-lite)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -38,6 +42,7 @@ runs:
         REPO_NAME: ${{ inputs.repo-name }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
+        GEMINI_MODEL: ${{ inputs.gemini-model }}
       run: |
         python ${{ github.action_path }}/generate_changelog.py
 

--- a/.github/actions/bot-changelog-generator/generate_changelog.py
+++ b/.github/actions/bot-changelog-generator/generate_changelog.py
@@ -21,7 +21,8 @@ Environment Variables:
     PR_NUMBER: The PR number to analyze
     REPO_NAME: The repository name (e.g., openwisp/openwisp-utils)
     GITHUB_TOKEN: GitHub token for API access
-    GEMINI_MODEL: Model to use (default: 'gemini-2.5-flash-lite')
+    GEMINI_MODEL: Model to use (default: 'gemini-2.5-flash-lite'). An unset or
+        empty value falls back to the default, mirroring the CI-failure bot.
 """
 
 import os
@@ -40,7 +41,10 @@ CHANGELOG_BOT_MARKER = "<!-- openwisp-changelog-bot -->"
 CHANGELOG_COMMENT_INTRO = "Proposed change log entry:"
 COMMIT_SUBJECT_LIMIT = 72
 COMMIT_BODY_MAX_NONEMPTY_LINES = 10
-MAX_GENERATION_ATTEMPTS = 3
+# Keep this low: each attempt is one Gemini request, and the bot shares a
+# per-model daily request quota (RPD) with the other OpenWISP bots.
+MAX_GENERATION_ATTEMPTS = 2
+DEFAULT_GEMINI_MODEL = "gemini-2.5-flash-lite"
 COMMIT_MESSAGE_RULE_CONTEXT_FILES = (
     "openwisp_utils/releaser/commitizen.py",
     "openwisp_utils/releaser/tests/test_commitizen_rules.py",
@@ -62,6 +66,29 @@ def get_env_or_exit(name: str) -> str:
         print(f"Error: {name} environment variable is required", file=sys.stderr)
         sys.exit(1)
     return value
+
+
+def resolve_model() -> str:
+    """Resolve the Gemini model from the environment.
+
+    Mirrors the CI-failure bot: an unset, empty, or whitespace-only
+    ``GEMINI_MODEL`` (for example an empty ``${{ vars.GEMINI_MODEL }}``)
+    falls back to the default model.
+    """
+    raw_model = os.environ.get("GEMINI_MODEL", "").strip()
+    return raw_model or DEFAULT_GEMINI_MODEL
+
+
+def _is_quota_error(error_message: str) -> bool:
+    """Return True if the error looks like a Gemini quota / rate-limit error."""
+    lowered = error_message.lower()
+    return (
+        "429" in lowered
+        or "resource_exhausted" in lowered
+        or "quota" in lowered
+        or "rate limit" in lowered
+        or "rate-limit" in lowered
+    )
 
 
 def github_api_request(endpoint: str, token: str) -> dict:
@@ -229,6 +256,16 @@ def call_gemini(
         error_msg = str(e)
         error_msg = re.sub(r"key=\S+", "key=***", error_msg)
         error_msg = re.sub(r"Bearer\s+\S+", "Bearer ***", error_msg)
+        if _is_quota_error(error_msg):
+            # Daily quota (RPD) exhaustion is not a code problem and must not
+            # mark the workflow as failed. Skip gracefully like the CI-failure
+            # bot does on API errors.
+            print(
+                f"::warning::Gemini quota exhausted; skipping changelog "
+                f"suggestion: {error_msg}",
+                file=sys.stderr,
+            )
+            sys.exit(0)
         print(f"Gemini API error: {error_msg}", file=sys.stderr)
         sys.exit(1)
 
@@ -623,7 +660,7 @@ def main():
         print("Changelog comment already exists, skipping.")
         return
     api_key = get_env_or_exit("GEMINI_API_KEY")
-    model = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
+    model = resolve_model()
     pr_details = get_pr_details(repo, pr_number, github_token)
     base_branch = pr_details["base_branch"]
     diff = get_pr_diff(base_branch)

--- a/.github/actions/bot-changelog-generator/generate_changelog.py
+++ b/.github/actions/bot-changelog-generator/generate_changelog.py
@@ -30,6 +30,7 @@ import re
 import secrets
 import subprocess
 import sys
+import textwrap
 from html import escape
 
 from google import genai
@@ -50,6 +51,11 @@ COMMIT_MESSAGE_RULE_CONTEXT_FILES = (
     "openwisp_utils/releaser/tests/test_commitizen_rules.py",
 )
 COMMIT_MESSAGE_RULE_CONTEXT_LIMIT = 6000
+ISSUE_FOOTER_RE = re.compile(
+    r"^(?:Close|Closes|Closed|Fix|Fixes|Fixed|Resolve|Resolves|Resolved|Related to)"
+    r"(?:\s+#\d+)+\.?$",
+    re.IGNORECASE,
+)
 
 
 class _CommitizenConfig:
@@ -89,6 +95,57 @@ def _is_quota_error(error_message: str) -> bool:
         or "rate limit" in lowered
         or "rate-limit" in lowered
     )
+
+
+def _flush_body_paragraph(
+    normalized_body_lines: list[str], paragraph: list[str]
+) -> None:
+    """Wrap buffered body text into normalized commit-message lines."""
+    if not paragraph:
+        return
+    paragraph_text = " ".join(line.strip() for line in paragraph)
+    normalized_body_lines.extend(
+        textwrap.wrap(
+            paragraph_text,
+            width=COMMIT_SUBJECT_LIMIT,
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+    )
+    paragraph.clear()
+
+
+def normalize_changelog_output(text: str) -> str:
+    """Normalize locally fixable formatting in a generated commit message."""
+    text = text.strip()
+    if "\n\n" not in text:
+        return text
+    subject, _, body = text.partition("\n\n")
+    if not body.strip():
+        return text
+    normalized_body_lines = []
+    paragraph = []
+    # Buffer regular body lines so existing hard-wrapped text is reflowed as
+    # one paragraph instead of preserving Gemini's arbitrary line breaks.
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            _flush_body_paragraph(normalized_body_lines, paragraph)
+            if normalized_body_lines and normalized_body_lines[-1] != "":
+                normalized_body_lines.append("")
+        elif ISSUE_FOOTER_RE.match(stripped):
+            # Issue footers are semantically meaningful commit metadata, so do
+            # not merge or wrap them into the preceding paragraph.
+            _flush_body_paragraph(normalized_body_lines, paragraph)
+            normalized_body_lines.append(stripped)
+        else:
+            paragraph.append(stripped)
+    _flush_body_paragraph(normalized_body_lines, paragraph)
+    while normalized_body_lines and normalized_body_lines[-1] == "":
+        normalized_body_lines.pop()
+    if not normalized_body_lines:
+        return subject.strip()
+    return f"{subject.strip()}\n\n" + "\n".join(normalized_body_lines)
 
 
 def github_api_request(endpoint: str, token: str) -> dict:
@@ -499,9 +556,9 @@ def generate_changelog_entry(
             validation_errors=validation_errors or None,
             attempt=attempt,
         )
-        latest_entry = call_gemini(
-            user_data_prompt, system_instruction, api_key, model
-        ).strip()
+        latest_entry = normalize_changelog_output(
+            call_gemini(user_data_prompt, system_instruction, api_key, model)
+        )
         validation_errors = get_changelog_validation_errors(
             latest_entry, changelog_format
         )
@@ -680,8 +737,8 @@ def main():
     if validation_errors:
         print(
             "::warning::Generated changelog entry failed validation against "
-            "OpenWISP commit message rules after 3 attempts. Posting the last "
-            "attempt anyway.",
+            "OpenWISP commit message rules after "
+            f"{MAX_GENERATION_ATTEMPTS} attempts. Posting the last attempt anyway.",
             file=sys.stderr,
         )
         for error in validation_errors:

--- a/.github/actions/bot-changelog-generator/test_generate_changelog.py
+++ b/.github/actions/bot-changelog-generator/test_generate_changelog.py
@@ -30,6 +30,7 @@ from generate_changelog import (  # noqa: E402
     get_pr_diff,
     has_existing_changelog_comment,
     post_github_comment,
+    resolve_model,
     validate_changelog_output,
 )
 
@@ -53,6 +54,32 @@ class TestGetEnvOrExit(unittest.TestCase):
             with self.assertRaises(SystemExit) as context:
                 get_env_or_exit("EMPTY_VAR")
             self.assertEqual(context.exception.code, 1)
+
+
+class TestResolveModel(unittest.TestCase):
+    """Tests for resolve_model: GEMINI_MODEL env resolution."""
+
+    def test_returns_env_model_when_set(self):
+        with patch.dict(os.environ, {"GEMINI_MODEL": "gemini-2.5-flash"}):
+            self.assertEqual(resolve_model(), "gemini-2.5-flash")
+
+    def test_returns_default_when_unset(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(resolve_model(), "gemini-2.5-flash-lite")
+
+    def test_returns_default_when_empty(self):
+        # Regression: an empty ``${{ vars.GEMINI_MODEL }}`` forwards an empty
+        # string, which must still fall back to the default model.
+        with patch.dict(os.environ, {"GEMINI_MODEL": ""}):
+            self.assertEqual(resolve_model(), "gemini-2.5-flash-lite")
+
+    def test_returns_default_when_whitespace(self):
+        with patch.dict(os.environ, {"GEMINI_MODEL": "   "}):
+            self.assertEqual(resolve_model(), "gemini-2.5-flash-lite")
+
+    def test_strips_surrounding_whitespace(self):
+        with patch.dict(os.environ, {"GEMINI_MODEL": "  gemini-2.5-flash  "}):
+            self.assertEqual(resolve_model(), "gemini-2.5-flash")
 
 
 class TestGetPrDetails(unittest.TestCase):
@@ -309,6 +336,21 @@ class TestCallGemini(unittest.TestCase):
                 "Test prompt", "System instruction", "api_key", "gemini-2.5-flash-lite"
             )
         self.assertEqual(context.exception.code, 1)
+
+    @patch("generate_changelog.genai")
+    def test_exits_zero_on_quota_error(self, mock_genai):
+        # Quota / RPD exhaustion must not turn the workflow red; it should skip
+        # gracefully (exit 0) like the CI-failure bot does on API errors.
+        mock_client = MagicMock()
+        mock_client.models.generate_content.side_effect = Exception(
+            "429 RESOURCE_EXHAUSTED: Quota exceeded for requests per day"
+        )
+        mock_genai.Client.return_value = mock_client
+        with self.assertRaises(SystemExit) as context:
+            call_gemini(
+                "Test prompt", "System instruction", "api_key", "gemini-2.5-flash-lite"
+            )
+        self.assertEqual(context.exception.code, 0)
 
     @patch("generate_changelog.genai")
     def test_passes_prompt_as_contents(self, mock_genai):
@@ -797,23 +839,22 @@ class TestGenerateChangelogEntry(unittest.TestCase):
         self, mock_call_gemini, mock_get_validation_errors
     ):
         pr_details = {"number": 1, "title": "Test", "body": "", "labels": []}
+        # Provide one entry/error per allowed attempt so the test tracks the
+        # configured MAX_GENERATION_ATTEMPTS instead of a hardcoded count.
+        attempts = MAX_GENERATION_ATTEMPTS
         mock_call_gemini.side_effect = [
-            "[change] Attempt 1\n\nBody",
-            "[change] Attempt 2\n\nBody",
-            "[change] Attempt 3\n\nBody",
+            f"[change] Attempt {i}\n\nBody" for i in range(1, attempts + 1)
         ]
         mock_get_validation_errors.side_effect = [
-            ["Error 1"],
-            ["Error 2"],
-            ["Error 3"],
+            [f"Error {i}"] for i in range(1, attempts + 1)
         ]
 
         entry, errors = generate_changelog_entry(
             pr_details, "", [], [], "rst", "api_key", "gemini-test"
         )
 
-        self.assertEqual(entry, "[change] Attempt 3\n\nBody")
-        self.assertEqual(errors, ["Error 3"])
+        self.assertEqual(entry, f"[change] Attempt {attempts}\n\nBody")
+        self.assertEqual(errors, [f"Error {attempts}"])
         self.assertEqual(mock_call_gemini.call_count, MAX_GENERATION_ATTEMPTS)
 
 

--- a/.github/actions/bot-changelog-generator/test_generate_changelog.py
+++ b/.github/actions/bot-changelog-generator/test_generate_changelog.py
@@ -29,6 +29,7 @@ from generate_changelog import (  # noqa: E402
     get_pr_details,
     get_pr_diff,
     has_existing_changelog_comment,
+    normalize_changelog_output,
     post_github_comment,
     resolve_model,
     validate_changelog_output,
@@ -648,6 +649,43 @@ class TestGetOpenwispCommitizen(unittest.TestCase):
 class TestValidateChangelogOutput(unittest.TestCase):
     """Tests for validate_changelog_output function."""
 
+    def test_normalizes_long_body_lines(self):
+        text = (
+            "[feature] Added new functionality\n\n"
+            "This body line is intentionally longer than seventy two characters "
+            "so the bot can wrap it locally without asking Gemini again."
+        )
+        normalized = normalize_changelog_output(text)
+        body = normalized.partition("\n\n")[2]
+        self.assertIn("\n", body)
+        self.assertTrue(
+            all(
+                len(line) <= COMMIT_SUBJECT_LIMIT
+                for line in body.splitlines()
+                if line.strip()
+            )
+        )
+
+    def test_normalization_preserves_issue_footers_and_blank_lines(self):
+        text = (
+            "[feature] Added new functionality #123\n\n"
+            "This body line is intentionally longer than seventy two characters "
+            "so it needs to be wrapped locally before validation.\n\n"
+            "Closes #123"
+        )
+        normalized = normalize_changelog_output(text)
+        self.assertTrue(normalized.endswith("\n\nCloses #123"))
+        self.assertEqual(normalized.count("\n\n"), 2)
+
+    def test_normalization_does_not_shorten_subject(self):
+        subject = (
+            "[feature] Added a very long subject that remains invalid because "
+            "shortening it could remove important context"
+        )
+        text = f"{subject}\n\nUseful body."
+        normalized = normalize_changelog_output(text)
+        self.assertEqual(normalized.splitlines()[0], subject)
+
     @patch("generate_changelog.get_openwisp_commitizen")
     def test_valid_feature_tag_rst(self, mock_get_commitizen):
         mock_plugin = MagicMock()
@@ -711,6 +749,20 @@ class TestValidateChangelogOutput(unittest.TestCase):
                 f"Commit message body line 1 must be {COMMIT_SUBJECT_LIMIT} "
                 "characters or shorter."
             ],
+        )
+
+    def test_invalid_subject_too_long(self):
+        text = (
+            "[feature] Added a very long subject that remains invalid because "
+            "shortening it could remove important context\n\n"
+            "Useful body."
+        )
+
+        errors = get_changelog_validation_errors(text, "rst")
+
+        self.assertEqual(
+            errors,
+            [f"commit message length exceeds the limit ({COMMIT_SUBJECT_LIMIT} chars)"],
         )
 
     def test_invalid_empty_text(self):
@@ -832,6 +884,39 @@ class TestGenerateChangelogEntry(unittest.TestCase):
         second_prompt = mock_call_gemini.call_args_list[1].args[0]
         self.assertIn("<validation_feedback>", second_prompt)
         self.assertIn("Title invalid", second_prompt)
+
+    @patch("generate_changelog.get_openwisp_commitizen")
+    @patch("generate_changelog.call_gemini")
+    def test_wraps_body_without_retrying(self, mock_call_gemini, mock_get_commitizen):
+        mock_plugin = MagicMock()
+        mock_plugin.schema_pattern.return_value = ".*"
+        mock_plugin.validate_commit_message.return_value = MagicMock(
+            is_valid=True, errors=[]
+        )
+        mock_get_commitizen.return_value = mock_plugin
+        pr_details = {"number": 1, "title": "Test", "body": "", "labels": []}
+        mock_call_gemini.return_value = (
+            "[change] Updated changelog bot\n\n"
+            "This body line is intentionally longer than seventy two characters "
+            "so the bot can wrap it locally without asking Gemini again.\n\n"
+            "Closes #123"
+        )
+
+        entry, errors = generate_changelog_entry(
+            pr_details, "", [], [], "rst", "api_key", "gemini-test"
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(mock_call_gemini.call_count, 1)
+        self.assertTrue(entry.endswith("\n\nCloses #123"))
+        body = entry.partition("\n\n")[2]
+        self.assertTrue(
+            all(
+                len(line) <= COMMIT_SUBJECT_LIMIT
+                for line in body.splitlines()
+                if line.strip()
+            )
+        )
 
     @patch("generate_changelog.get_changelog_validation_errors")
     @patch("generate_changelog.call_gemini")

--- a/.github/workflows/reusable-bot-changelog.yml
+++ b/.github/workflows/reusable-bot-changelog.yml
@@ -56,3 +56,4 @@ jobs:
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
           pr-number: ${{ inputs.pr_number }}
           repo-name: ${{ github.repository }}
+          gemini-model: ${{ vars.GEMINI_MODEL }}

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -424,6 +424,14 @@ The bot supports a configurable retry classifier mode via
   LLM call is skipped when the heuristic already matched.
 - Any other value (including empty/typo): heuristic-only retry.
 
+**Model configuration**
+
+By default the bot uses ``gemini-2.5-flash-lite``. To use a different model
+(for example a paid tier with a higher or unlimited daily request quota), set
+the ``GEMINI_MODEL`` repository or organization variable. An unset or empty
+value keeps the default. The same variable also controls the changelog bot, so
+setting it once at the organization level repoints both bots together.
+
 This workflow is intended to be triggered via the ``workflow_run`` event
 after your primary test suite concludes. It features strict
 cross-repository concurrency locks and token limits to prevent PR spam on
@@ -549,6 +557,13 @@ to secrets, and is the one that generates and posts the changelog comment.
 - ``OPENWISP_BOT_APP_ID`` (required): OpenWISP Bot GitHub App ID.
 - ``OPENWISP_BOT_PRIVATE_KEY`` (required): OpenWISP Bot GitHub App private
   key.
+
+**Model configuration**
+
+The changelog bot uses ``gemini-2.5-flash-lite`` by default and honors the same
+``GEMINI_MODEL`` repository or organization variable as the CI failure bot. Set
+it to point both bots at a model with a higher daily request quota; leave it
+unset to keep the default.
 
 **Setup for Other Repositories**
 

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -426,11 +426,12 @@ The bot supports a configurable retry classifier mode via
 
 **Model configuration**
 
-By default the bot uses ``gemini-2.5-flash-lite``. To use a different model
-(for example a paid tier with a higher or unlimited daily request quota), set
-the ``GEMINI_MODEL`` repository or organization variable. An unset or empty
-value keeps the default. The same variable also controls the changelog bot, so
-setting it once at the organization level repoints both bots together.
+By default the bot uses ``gemini-2.5-flash-lite``. To use a different
+model (for example a paid tier with a higher or unlimited daily request
+quota), set the ``GEMINI_MODEL`` repository or organization variable. An
+unset or empty value keeps the default. The same variable also controls
+the changelog bot, so setting it once at the organization level repoints
+both bots together.
 
 This workflow is intended to be triggered via the ``workflow_run`` event
 after your primary test suite concludes. It features strict
@@ -560,10 +561,15 @@ to secrets, and is the one that generates and posts the changelog comment.
 
 **Model configuration**
 
-The changelog bot uses ``gemini-2.5-flash-lite`` by default and honors the same
-``GEMINI_MODEL`` repository or organization variable as the CI failure bot. Set
-it to point both bots at a model with a higher daily request quota; leave it
-unset to keep the default.
+The changelog bot uses ``gemini-2.5-flash-lite`` by default and honors the
+same ``GEMINI_MODEL`` repository or organization variable as the CI
+failure bot. Set it to point both bots at a model with a higher daily
+request quota; leave it unset to keep the default.
+
+The bot normalizes generated commit-message body text locally before
+validation, wrapping long body lines while preserving issue footers such
+as ``Closes #123``. This avoids spending extra Gemini requests on
+formatting issues that can be fixed deterministically.
 
 **Setup for Other Repositories**
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

No existing issue, it's a relatively small and trivial change.

## Description of Changes

This PR hardens the changelog bot against Gemini API quota limits, adds model configurability, and ensures the GitHub Action workflow exits gracefully instead of failing when quotas are exhausted.

### Context

The changelog bot was frequently failing workflows due to hitting the Gemini free-tier quota (`RequestsPerDayPerProjectPerModel`, 20 requests/day). This was compounded by two issues:

1. The bot lacked a way to switch models.
2. It could consume up to 3 requests per individual pull request.

Unlike the CI failure bot (which swallows these errors and stays green), the changelog bot would cause the entire workflow to turn red.

### Changes

* **Configurable Models:** Forwarded the `GEMINI_MODEL` variable through the action and reusable workflow, allowing a single variable to control both the changelog and CI failure bots.
* **Fallback Handling:** Hardened model resolution to automatically fall back to the default model if the provided value is empty.
* **Reduced API Overhead:** Lowered the generation retry limit from 3 to 2 to conserve daily quota.
* **Graceful Degradation:** Modified the bot to exit cleanly on quota errors so that API exhaustion no longer triggers a workflow failure.
* **Deterministic Output:** Normalized the changelog bot's output to ensure consistency across runs.