### PR TITLE
[change] CI: Download recent firefox build to show issue with MV2 -> MV3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
       - name: QA checks
         run: ./run-qa-checks
 
+      - name: Install Firefox with MV2 fully removed
+        run: |
+          wget -q "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US" -O /tmp/firefox.tar.bz2
+          tar xjf /tmp/firefox.tar.bz2 -C /tmp
+          echo "GECKO_BIN=/tmp/firefox/firefox" >> $GITHUB_ENV
+
+      - name: Check Firefox version
+        run: /tmp/firefox/firefox --version
+
       - name: Tests
         if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
         run: ./runtests


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Demonstrate #696

## Description of Changes

This is a **demonstration-only PR** — no source code is changed. It adds two
steps to the CI workflow to prove that Firefox ≥135 refuses to load the
Manifest v2 console-capture extension.

### Changes to `.github/workflows/ci.yml` (+9 lines)

1. **Install Firefox from Mozilla CDN** before running tests:
   ```yaml
   - name: Install Firefox with MV2 fully removed
     run: |
       wget -q "..." -O /tmp/firefox.tar.bz2
       tar xjf /tmp/firefox.tar.bz2 -C /tmp
       echo "GECKO_BIN=/tmp/firefox/firefox" >> $GITHUB_ENV
   ```
   The directly-downloaded Firefox has MV2 support fully removed, unlike the
   distro-packaged version on `ubuntu-24.04` which still permits MV2 temporary
   add-ons (current CI passes).

2. **Print Firefox version** so the CI log clearly shows which build is
   running:
   ```yaml
   - name: Check Firefox version
     run: /tmp/firefox/firefox --version
   ```

### Expected CI result

```
FAIL: test_get_browser_logs (test_project.tests.test_selenium
       .TestFirefoxSeleniumHelpers.test_get_browser_logs)
AssertionError: None != []
```

The root cause is `openwisp_utils/tests/firefox-extensions/console_capture_extension/manifest.json`
using `manifest_version: 2`, which modern Firefox refuses to load.
`get_browser_logs()` → `execute_script("return window._console_logs")`
returns JS `undefined` → Python `None` instead of the expected `[]`.

### Next step

The actual fix PR would:
1. Upgrade the extension manifest to **v3** (`manifest_version: 3` +
   `host_permissions`).
2. Add a fallback in `get_browser_logs()` so it works when the extension fails
   to load (e.g. on `about:blank` where content scripts never run).
