### PR TITLE
[chores] Changelog bot: asked LLM to use past tense

### DIFF
--- a/.github/actions/bot-changelog-generator/generate_changelog.py
+++ b/.github/actions/bot-changelog-generator/generate_changelog.py
@@ -465,6 +465,7 @@ def build_prompt(
         f"- Keep the first line within {COMMIT_SUBJECT_LIMIT} characters, "
         "including the tag and spaces\n"
         "- Capitalize the first word after the tag\n"
+        "- Use past tense for the commit message (e.g., 'Added', 'Fixed', 'Changed')\n"
         "- The message must contain a body after one blank line\n"
         "- If an issue number appears in the title, the same issue number must "
         "appear in the body footer\n"

--- a/.github/actions/bot-changelog-generator/test_generate_changelog.py
+++ b/.github/actions/bot-changelog-generator/test_generate_changelog.py
@@ -392,6 +392,7 @@ class TestBuildPrompt(unittest.TestCase):
             f"within {COMMIT_SUBJECT_LIMIT} characters, including the tag and spaces",
             system_instruction,
         )
+        self.assertIn("Use past tense for the commit message", system_instruction)
         self.assertIn(
             "If any rule below is broken, the output is invalid.",
             system_instruction,


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

No existing issue. Small refinement, issue not needed.

## Description of Changes

The changelog bot's system prompt did not explicitly instruct the LLM to use past tense for the generated commit message. The example output happened to use past tense ('Added'), but there was no explicit rule enforcing it.

Changes:
- Added the rule: 'Use past tense for the commit message (e.g., Added, Fixed, Changed)' to the system instruction in build_prompt().
- Updated the corresponding test in test_builds_basic_prompt to assert that this rule is present in the prompt.

All tests and QA checks pass.

## Screenshot

Not applicable.