### PR TITLE
[change] Releaser: added generic package type to replace OpenWrt-specific flow

### DIFF
--- a/openwisp_utils/releaser/config.py
+++ b/openwisp_utils/releaser/config.py
@@ -75,7 +75,7 @@ def _handle_python_version(config):
                 try:
                     version_tuple = ast.literal_eval(f"({version_match.group(1)})")
                     config["CURRENT_VERSION"] = list(version_tuple)
-                except (ValueError, SyntaxError):
+                except (ValueError, SyntaxError, TypeError):
                     config["CURRENT_VERSION"] = None
                 return
 

--- a/openwisp_utils/releaser/config.py
+++ b/openwisp_utils/releaser/config.py
@@ -27,7 +27,7 @@ def get_package_type_from_setup():
         ".ansible-lint": "ansible",
         # The VERSION file check should be last to avoid false positives
         # with other package types
-        "VERSION": "version_file",
+        "VERSION": "generic",
     }
     for filename, package_type in package_type_files.items():
         if os.path.exists(filename):
@@ -168,7 +168,7 @@ def _handle_ansible_version(config):
             config["CURRENT_VERSION"] = None
 
 
-def _handle_version_file_version(config):
+def _handle_generic_version(config):
     """Handles version detection for packages using a root VERSION file."""
     with open("VERSION", "r") as f:
         version_str = f.read().strip()
@@ -197,7 +197,7 @@ PACKAGE_VERSION_HANDLERS = {
     "npm": _handle_npm_version,
     "docker": _handle_docker_version,
     "ansible": _handle_ansible_version,
-    "version_file": _handle_version_file_version,
+    "generic": _handle_generic_version,
 }
 
 

--- a/openwisp_utils/releaser/config.py
+++ b/openwisp_utils/releaser/config.py
@@ -52,24 +52,32 @@ def detect_changelog_style(changelog_path):
 
 
 def _handle_python_version(config):
-    """Handles version detection for Python packages."""
+    """Handles version detection for Python packages.
+
+    Checks __init__.py first, then falls back to version.py.
+    """
     project_name = get_package_name_from_setup()
     if not project_name:
         return
     package_directory = project_name.replace("-", "_")
-    init_py_path = os.path.join(package_directory, "__init__.py")
-    if not os.path.exists(init_py_path):
-        return
-    with open(init_py_path, "r") as f:
-        content = f.read()
-        version_match = re.search(r"^VERSION\s*=\s*\((.*)\)", content, re.M)
-        if version_match:
-            config["version_path"] = init_py_path
-            try:
-                version_tuple = ast.literal_eval(f"({version_match.group(1)})")
-                config["CURRENT_VERSION"] = list(version_tuple)
-            except (ValueError, SyntaxError):
-                config["CURRENT_VERSION"] = None
+    candidate_files = [
+        os.path.join(package_directory, "__init__.py"),
+        os.path.join(package_directory, "version.py"),
+    ]
+    for version_path in candidate_files:
+        if not os.path.exists(version_path):
+            continue
+        with open(version_path, "r") as f:
+            content = f.read()
+            version_match = re.search(r"^VERSION\s*=\s*\((.*)\)", content, re.M)
+            if version_match:
+                config["version_path"] = version_path
+                try:
+                    version_tuple = ast.literal_eval(f"({version_match.group(1)})")
+                    config["CURRENT_VERSION"] = list(version_tuple)
+                except (ValueError, SyntaxError):
+                    config["CURRENT_VERSION"] = None
+                return
 
 
 def _handle_npm_version(config):

--- a/openwisp_utils/releaser/config.py
+++ b/openwisp_utils/releaser/config.py
@@ -25,7 +25,9 @@ def get_package_type_from_setup():
         "package.json": "npm",
         "docker-compose.yml": "docker",
         ".ansible-lint": "ansible",
-        ".luacheckrc": "openwrt",
+        # The VERSION file check should be last to avoid false positives
+        # with other package types
+        "VERSION": "version_file",
     }
     for filename, package_type in package_type_files.items():
         if os.path.exists(filename):
@@ -166,10 +168,8 @@ def _handle_ansible_version(config):
             config["CURRENT_VERSION"] = None
 
 
-def _handle_openwrt_version(config):
-    """Handles version detection for OpenWRT packages."""
-    if not os.path.exists("VERSION"):
-        return
+def _handle_version_file_version(config):
+    """Handles version detection for packages using a root VERSION file."""
     with open("VERSION", "r") as f:
         version_str = f.read().strip()
         if not version_str:
@@ -197,7 +197,7 @@ PACKAGE_VERSION_HANDLERS = {
     "npm": _handle_npm_version,
     "docker": _handle_docker_version,
     "ansible": _handle_ansible_version,
-    "openwrt": _handle_openwrt_version,
+    "version_file": _handle_version_file_version,
 }
 
 

--- a/openwisp_utils/releaser/config.py
+++ b/openwisp_utils/releaser/config.py
@@ -54,7 +54,8 @@ def detect_changelog_style(changelog_path):
 def _handle_python_version(config):
     """Handles version detection for Python packages.
 
-    Checks __init__.py first, then falls back to version.py.
+    Checks __init__.py first, then falls back to version.py (eg:
+    netjsonconfig, netdiff).
     """
     project_name = get_package_name_from_setup()
     if not project_name:

--- a/openwisp_utils/releaser/tests/conftest.py
+++ b/openwisp_utils/releaser/tests/conftest.py
@@ -132,7 +132,7 @@ def create_ansible_lint():
 
 
 def _create_luacheckrc(path: Path):
-    """Helper to create .luacheckrc file for OpenWRT agents."""
+    """Helper to create .luacheckrc file."""
     (path / ".luacheckrc").write_text("std = 'min'")
 
 

--- a/openwisp_utils/releaser/tests/conftest.py
+++ b/openwisp_utils/releaser/tests/conftest.py
@@ -41,6 +41,20 @@ def create_package_dir_with_version():
     return _create_package_dir_with_version
 
 
+def _create_package_dir_with_version_in_version_py(
+    path: Path, name="my-test-package", version_str="VERSION = (1, 2, 3, 'final')"
+):
+    """Creates a package with VERSION tuple in version.py instead of __init__.py."""
+    pkg_dir = path / name.replace("-", "_")
+    pkg_dir.mkdir(exist_ok=True)
+    (pkg_dir / "version.py").write_text(version_str)
+
+
+@pytest.fixture
+def create_package_dir_with_version_in_version_py():
+    return _create_package_dir_with_version_in_version_py
+
+
 def _create_changelog(path: Path, ext="rst"):
     (path / f"CHANGES.{ext}").write_text("Changelog")
 

--- a/openwisp_utils/releaser/tests/conftest.py
+++ b/openwisp_utils/releaser/tests/conftest.py
@@ -113,6 +113,16 @@ def create_ansible_lint():
     return _create_ansible_lint
 
 
+def _create_luacheckrc(path: Path):
+    """Helper to create .luacheckrc file for OpenWRT agents."""
+    (path / ".luacheckrc").write_text("std = 'min'")
+
+
+@pytest.fixture
+def create_luacheckrc():
+    return _create_luacheckrc
+
+
 def _create_ansible_version_file(path: Path, version="1.2.3"):
     """Helper to create templates/openwisp2/version.py for ansible projects."""
     templates_dir = path / "templates" / "openwisp2"
@@ -125,18 +135,8 @@ def create_ansible_version_file():
     return _create_ansible_version_file
 
 
-def _create_luacheckrc(path: Path):
-    """Helper to create .luacheckrc file for OpenWRT agents."""
-    (path / ".luacheckrc").write_text("std = 'min'")
-
-
-@pytest.fixture
-def create_luacheckrc():
-    return _create_luacheckrc
-
-
 def _create_version_file(path: Path, version="1.2.3"):
-    """Helper to create VERSION file for OpenWRT agents."""
+    """Helper to create VERSION file for version_file package type."""
     (path / "VERSION").write_text(version)
 
 

--- a/openwisp_utils/releaser/tests/conftest.py
+++ b/openwisp_utils/releaser/tests/conftest.py
@@ -136,7 +136,7 @@ def create_ansible_version_file():
 
 
 def _create_version_file(path: Path, version="1.2.3"):
-    """Helper to create VERSION file for version_file package type."""
+    """Helper to create VERSION file for generic package type."""
     (path / "VERSION").write_text(version)
 
 

--- a/openwisp_utils/releaser/tests/conftest.py
+++ b/openwisp_utils/releaser/tests/conftest.py
@@ -44,8 +44,7 @@ def create_package_dir_with_version():
 def _create_package_dir_with_version_in_version_py(
     path: Path, name="my-test-package", version_str="VERSION = (1, 2, 3, 'final')"
 ):
-    """
-    Create a package using the netjsonconfig/netdiff version layout.
+    """Create a package using the netjsonconfig/netdiff version layout.
 
     Unlike the standard layout, the VERSION tuple is defined in
     ``version.py`` instead of ``__init__.py``.

--- a/openwisp_utils/releaser/tests/conftest.py
+++ b/openwisp_utils/releaser/tests/conftest.py
@@ -44,7 +44,12 @@ def create_package_dir_with_version():
 def _create_package_dir_with_version_in_version_py(
     path: Path, name="my-test-package", version_str="VERSION = (1, 2, 3, 'final')"
 ):
-    """Creates a package with VERSION tuple in version.py instead of __init__.py."""
+    """
+    Create a package using the netjsonconfig/netdiff version layout.
+
+    Unlike the standard layout, the VERSION tuple is defined in
+    ``version.py`` instead of ``__init__.py``.
+    """
     pkg_dir = path / name.replace("-", "_")
     pkg_dir.mkdir(exist_ok=True)
     (pkg_dir / "version.py").write_text(version_str)

--- a/openwisp_utils/releaser/tests/test_config.py
+++ b/openwisp_utils/releaser/tests/test_config.py
@@ -354,45 +354,75 @@ def test_ansible_package_malformed_version(
     assert config["CURRENT_VERSION"] is None
 
 
-# OpenWRT Package Tests
-def test_openwrt_package_detection(
-    project_dir, create_luacheckrc, create_version_file, create_changelog, init_git_repo
+# VERSION File Package Tests
+def test_version_file_package_detection(
+    project_dir, create_version_file, create_changelog, init_git_repo
 ):
-    """Tests that openwrt package type is detected when .luacheckrc exists."""
-    create_luacheckrc(project_dir)
+    """Tests that version_file package type is detected when VERSION file exists."""
     create_version_file(project_dir, version="1.2.3")
     create_changelog(project_dir)
     init_git_repo(project_dir)
     config = load_config()
-    assert config["package_type"] == "openwrt"
+    assert config["package_type"] == "version_file"
     assert config["version_path"] == "VERSION"
     assert config["CURRENT_VERSION"] == [1, 2, 3, "final"]
 
 
-def test_openwrt_without_version_file(
-    project_dir, create_luacheckrc, create_changelog, init_git_repo
+def test_version_file_fallback_without_other_config(
+    project_dir, create_version_file, create_changelog, init_git_repo
 ):
-    """Tests openwrt package without VERSION file."""
-    create_luacheckrc(project_dir)
+    """Tests that VERSION file is used as fallback when no other package type is detected."""
+    create_version_file(project_dir, version="2.0.1")
     create_changelog(project_dir)
     init_git_repo(project_dir)
     config = load_config()
-    assert config["package_type"] == "openwrt"
-    assert config["version_path"] is None
+    assert config["package_type"] == "version_file"
+    assert config["version_path"] == "VERSION"
+    assert config["CURRENT_VERSION"] == [2, 0, 1, "final"]
+
+
+def test_version_file_invalid_version(
+    project_dir, create_version_file, create_changelog, init_git_repo
+):
+    """Tests version_file package with invalid version format gracefully."""
+    create_version_file(project_dir, version="1.2")  # Invalid: only 2 parts
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] == "version_file"
+    assert config["version_path"] == "VERSION"
     assert config["CURRENT_VERSION"] is None
 
 
-def test_openwrt_invalid_version(
-    project_dir, create_luacheckrc, create_changelog, init_git_repo
+def test_version_file_not_fallback_when_other_type_detected(
+    project_dir,
+    create_setup_py,
+    create_package_dir_with_version,
+    create_version_file,
+    create_changelog,
+    init_git_repo,
 ):
-    """Tests openwrt package with invalid version format gracefully."""
-    create_luacheckrc(project_dir)
-    (project_dir / "VERSION").write_text("1.2")  # Invalid: only 2 parts
+    """Tests that VERSION file is not used as fallback when another package type is detected."""
+    create_setup_py(project_dir)
+    create_package_dir_with_version(project_dir)
+    create_version_file(project_dir, version="1.2.3")
     create_changelog(project_dir)
     init_git_repo(project_dir)
     config = load_config()
-    assert config["package_type"] == "openwrt"
-    assert config["version_path"] == "VERSION"
+    assert config["package_type"] == "python"
+    assert config["version_path"] == "my_test_package/__init__.py"
+
+
+def test_luacheckrc_does_not_trigger_detection(
+    project_dir, create_luacheckrc, create_changelog, init_git_repo
+):
+    """Tests that .luacheckrc alone does not trigger any package type detection."""
+    create_luacheckrc(project_dir)
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] is None
+    assert config["version_path"] is None
     assert config["CURRENT_VERSION"] is None
 
 

--- a/openwisp_utils/releaser/tests/test_config.py
+++ b/openwisp_utils/releaser/tests/test_config.py
@@ -185,14 +185,18 @@ def test_config_version_non_iterable_type_error(
     assert config["CURRENT_VERSION"] is None
 
 
-def test_python_version_detection_from_version_py(
+def test_python_version_detection_from_version_py_for_netjsonconfig_compatibility(
     project_dir,
     create_setup_py,
     create_package_dir_with_version_in_version_py,
     create_changelog,
     init_git_repo,
 ):
-    """Tests that Python version is detected from version.py when __init__.py has no VERSION."""
+    """Ensure version detection supports the netjsonconfig/netdiff layout.
+
+    These projects define VERSION in ``version.py`` rather than in
+    ``__init__.py``, which differs from the standard project layout.
+    """
     create_setup_py(project_dir)
     create_package_dir_with_version_in_version_py(project_dir)
     create_changelog(project_dir)
@@ -203,14 +207,13 @@ def test_python_version_detection_from_version_py(
     assert config["CURRENT_VERSION"] == [1, 2, 3, "final"]
 
 
-def test_python_version_prefers_init_py_over_version_py(
+def test_python_version_ignores_version_py_when_init_py_defines_version(
     project_dir,
     create_setup_py,
     create_package_dir_with_version,
     create_changelog,
     init_git_repo,
 ):
-    """Tests that __init__.py is preferred over version.py when both have VERSION."""
     create_setup_py(project_dir)
     # Create both __init__.py and version.py with VERSION
     pkg_dir = project_dir / "my_test_package"
@@ -225,13 +228,12 @@ def test_python_version_prefers_init_py_over_version_py(
     assert config["CURRENT_VERSION"] == [1, 0, 0, "final"]
 
 
-def test_python_version_fallback_to_version_py_when_init_py_has_no_version(
+def test_python_version_detection_for_netjsonconfig_when_init_py_lacks_version(
     project_dir,
     create_setup_py,
     create_changelog,
     init_git_repo,
 ):
-    """Tests fallback to version.py when __init__.py exists but has no VERSION tuple."""
     create_setup_py(project_dir)
     pkg_dir = project_dir / "my_test_package"
     pkg_dir.mkdir(exist_ok=True)

--- a/openwisp_utils/releaser/tests/test_config.py
+++ b/openwisp_utils/releaser/tests/test_config.py
@@ -169,6 +169,22 @@ def test_config_malformed_version_literal_eval_fails(
     assert config["CURRENT_VERSION"] is None
 
 
+def test_config_version_non_iterable_type_error(
+    project_dir, create_setup_py, create_package_dir_with_version, create_changelog
+):
+    """Tests that TypeError is caught when version tuple is non-iterable.
+
+    For example, VERSION = (1) evaluates to an integer, and list(1) raises
+    TypeError.
+    """
+    create_setup_py(project_dir)
+    create_package_dir_with_version(project_dir, version_str="VERSION = (1)")
+    create_changelog(project_dir)
+    config = load_config()
+    # Should gracefully handle the TypeError and return None
+    assert config["CURRENT_VERSION"] is None
+
+
 def test_python_version_detection_from_version_py(
     project_dir,
     create_setup_py,

--- a/openwisp_utils/releaser/tests/test_config.py
+++ b/openwisp_utils/releaser/tests/test_config.py
@@ -491,6 +491,61 @@ def test_generic_not_fallback_when_other_type_detected(
     assert config["version_path"] == "my_test_package/__init__.py"
 
 
+def test_generic_not_fallback_when_npm_detected(
+    project_dir,
+    create_package_json,
+    create_version_file,
+    create_changelog,
+    init_git_repo,
+):
+    """Tests that VERSION file is not used as fallback when npm package is detected."""
+    create_package_json(project_dir, version="1.2.3")
+    create_version_file(project_dir, version="1.5.0")
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] == "npm"
+    assert config["version_path"] == "package.json"
+
+
+def test_generic_not_fallback_when_docker_detected(
+    project_dir,
+    create_docker_compose,
+    create_docker_version_file,
+    create_version_file,
+    create_changelog,
+    init_git_repo,
+):
+    """Tests that VERSION file is not used as fallback when docker package is detected."""
+    create_docker_compose(project_dir)
+    create_docker_version_file(project_dir, version="1.2.3")
+    create_version_file(project_dir, version="1.5.0")
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] == "docker"
+    assert config["version_path"] == DOCKER_VERSION_PATH
+
+
+def test_generic_not_fallback_when_ansible_detected(
+    project_dir,
+    create_ansible_lint,
+    create_ansible_version_file,
+    create_version_file,
+    create_changelog,
+    init_git_repo,
+):
+    """Tests that VERSION file is not used as fallback when ansible package is detected."""
+    create_ansible_lint(project_dir)
+    create_ansible_version_file(project_dir, version="1.2.3")
+    create_version_file(project_dir, version="1.5.0")
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] == "ansible"
+    assert config["version_path"] == "templates/openwisp2/version.py"
+
+
 def test_luacheckrc_does_not_trigger_detection(
     project_dir, create_luacheckrc, create_changelog, init_git_repo
 ):

--- a/openwisp_utils/releaser/tests/test_config.py
+++ b/openwisp_utils/releaser/tests/test_config.py
@@ -354,21 +354,21 @@ def test_ansible_package_malformed_version(
     assert config["CURRENT_VERSION"] is None
 
 
-# VERSION File Package Tests
-def test_version_file_package_detection(
+# Generic Package Tests
+def test_generic_package_detection(
     project_dir, create_version_file, create_changelog, init_git_repo
 ):
-    """Tests that version_file package type is detected when VERSION file exists."""
+    """Tests that generic package type is detected when VERSION file exists."""
     create_version_file(project_dir, version="1.2.3")
     create_changelog(project_dir)
     init_git_repo(project_dir)
     config = load_config()
-    assert config["package_type"] == "version_file"
+    assert config["package_type"] == "generic"
     assert config["version_path"] == "VERSION"
     assert config["CURRENT_VERSION"] == [1, 2, 3, "final"]
 
 
-def test_version_file_fallback_without_other_config(
+def test_generic_fallback_without_other_config(
     project_dir, create_version_file, create_changelog, init_git_repo
 ):
     """Tests that VERSION file is used as fallback when no other package type is detected."""
@@ -376,25 +376,25 @@ def test_version_file_fallback_without_other_config(
     create_changelog(project_dir)
     init_git_repo(project_dir)
     config = load_config()
-    assert config["package_type"] == "version_file"
+    assert config["package_type"] == "generic"
     assert config["version_path"] == "VERSION"
     assert config["CURRENT_VERSION"] == [2, 0, 1, "final"]
 
 
-def test_version_file_invalid_version(
+def test_generic_invalid_version(
     project_dir, create_version_file, create_changelog, init_git_repo
 ):
-    """Tests version_file package with invalid version format gracefully."""
+    """Tests generic package with invalid version format gracefully."""
     create_version_file(project_dir, version="1.2")  # Invalid: only 2 parts
     create_changelog(project_dir)
     init_git_repo(project_dir)
     config = load_config()
-    assert config["package_type"] == "version_file"
+    assert config["package_type"] == "generic"
     assert config["version_path"] == "VERSION"
     assert config["CURRENT_VERSION"] is None
 
 
-def test_version_file_not_fallback_when_other_type_detected(
+def test_generic_not_fallback_when_other_type_detected(
     project_dir,
     create_setup_py,
     create_package_dir_with_version,

--- a/openwisp_utils/releaser/tests/test_config.py
+++ b/openwisp_utils/releaser/tests/test_config.py
@@ -169,6 +169,66 @@ def test_config_malformed_version_literal_eval_fails(
     assert config["CURRENT_VERSION"] is None
 
 
+def test_python_version_detection_from_version_py(
+    project_dir,
+    create_setup_py,
+    create_package_dir_with_version_in_version_py,
+    create_changelog,
+    init_git_repo,
+):
+    """Tests that Python version is detected from version.py when __init__.py has no VERSION."""
+    create_setup_py(project_dir)
+    create_package_dir_with_version_in_version_py(project_dir)
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] == "python"
+    assert config["version_path"] == "my_test_package/version.py"
+    assert config["CURRENT_VERSION"] == [1, 2, 3, "final"]
+
+
+def test_python_version_prefers_init_py_over_version_py(
+    project_dir,
+    create_setup_py,
+    create_package_dir_with_version,
+    create_changelog,
+    init_git_repo,
+):
+    """Tests that __init__.py is preferred over version.py when both have VERSION."""
+    create_setup_py(project_dir)
+    # Create both __init__.py and version.py with VERSION
+    pkg_dir = project_dir / "my_test_package"
+    pkg_dir.mkdir(exist_ok=True)
+    (pkg_dir / "__init__.py").write_text("VERSION = (1, 0, 0, 'final')")
+    (pkg_dir / "version.py").write_text("VERSION = (2, 0, 0, 'final')")
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] == "python"
+    assert config["version_path"] == "my_test_package/__init__.py"
+    assert config["CURRENT_VERSION"] == [1, 0, 0, "final"]
+
+
+def test_python_version_fallback_to_version_py_when_init_py_has_no_version(
+    project_dir,
+    create_setup_py,
+    create_changelog,
+    init_git_repo,
+):
+    """Tests fallback to version.py when __init__.py exists but has no VERSION tuple."""
+    create_setup_py(project_dir)
+    pkg_dir = project_dir / "my_test_package"
+    pkg_dir.mkdir(exist_ok=True)
+    (pkg_dir / "__init__.py").write_text("# No version here\n")
+    (pkg_dir / "version.py").write_text("VERSION = (3, 4, 5, 'final')")
+    create_changelog(project_dir)
+    init_git_repo(project_dir)
+    config = load_config()
+    assert config["package_type"] == "python"
+    assert config["version_path"] == "my_test_package/version.py"
+    assert config["CURRENT_VERSION"] == [3, 4, 5, "final"]
+
+
 # NPM Package Tests
 def test_npm_package_detection(
     project_dir, create_package_json, create_changelog, init_git_repo

--- a/openwisp_utils/releaser/tests/test_version_bumping.py
+++ b/openwisp_utils/releaser/tests/test_version_bumping.py
@@ -341,11 +341,11 @@ def test_bump_version_ansible():
     assert '__openwisp_version__ = "1.2.4"' in written_content
 
 
-# VERSION File Package Version Tests
-def test_get_current_version_version_file():
+# Generic Package Version Tests
+def test_get_current_version_generic():
     """Tests getting current version from a root VERSION file."""
     config = {
-        "package_type": "version_file",
+        "package_type": "generic",
         "version_path": "VERSION",
         "CURRENT_VERSION": [1, 2, 3, "final"],
     }
@@ -354,10 +354,10 @@ def test_get_current_version_version_file():
     assert version_type == "final"
 
 
-def test_bump_version_version_file():
+def test_bump_version_generic():
     """Tests bumping version for a package using a root VERSION file."""
     config = {
-        "package_type": "version_file",
+        "package_type": "generic",
         "version_path": "VERSION",
         "CURRENT_VERSION": [1, 2, 3, "final"],
     }

--- a/openwisp_utils/releaser/tests/test_version_bumping.py
+++ b/openwisp_utils/releaser/tests/test_version_bumping.py
@@ -383,4 +383,4 @@ def test_bump_version_generic():
         result = bump_version(config, "1.2.4")
     assert result is True
     written_content = m_open().write.call_args[0][0]
-    assert "1.2.4" in written_content
+    assert written_content == "1.2.4\n"

--- a/openwisp_utils/releaser/tests/test_version_bumping.py
+++ b/openwisp_utils/releaser/tests/test_version_bumping.py
@@ -67,6 +67,22 @@ def test_bump_version_success(mock_config):
     assert expected_content in written_content
 
 
+def test_bump_version_version_py():
+    """Tests bumping version when VERSION is in version.py."""
+    config = {
+        "package_type": "python",
+        "version_path": "my_test_package/version.py",
+        "CURRENT_VERSION": [1, 2, 3, "final"],
+    }
+    version_py_content = "VERSION = (1, 2, 3, 'final')\n"
+    m_open = mock_open(read_data=version_py_content)
+    with patch("os.path.exists", return_value=True), patch("builtins.open", m_open):
+        result = bump_version(config, "1.2.4")
+    assert result is True
+    written_content = m_open().write.call_args[0][0]
+    assert 'VERSION = (1, 2, 4, "final")' in written_content
+
+
 def test_bump_version_no_path_in_config(mock_config_no_path):
     result = bump_version(mock_config_no_path, "1.2.0")
     assert result is False

--- a/openwisp_utils/releaser/tests/test_version_bumping.py
+++ b/openwisp_utils/releaser/tests/test_version_bumping.py
@@ -341,11 +341,11 @@ def test_bump_version_ansible():
     assert '__openwisp_version__ = "1.2.4"' in written_content
 
 
-# OpenWRT Agents Package Version Tests
-def test_get_current_version_openwrt():
-    """Tests getting current version from OpenWRT VERSION file."""
+# VERSION File Package Version Tests
+def test_get_current_version_version_file():
+    """Tests getting current version from a root VERSION file."""
     config = {
-        "package_type": "openwrt",
+        "package_type": "version_file",
         "version_path": "VERSION",
         "CURRENT_VERSION": [1, 2, 3, "final"],
     }
@@ -354,10 +354,10 @@ def test_get_current_version_openwrt():
     assert version_type == "final"
 
 
-def test_bump_version_openwrt():
-    """Tests bumping version for OpenWRT in VERSION file."""
+def test_bump_version_version_file():
+    """Tests bumping version for a package using a root VERSION file."""
     config = {
-        "package_type": "openwrt",
+        "package_type": "version_file",
         "version_path": "VERSION",
         "CURRENT_VERSION": [1, 2, 3, "final"],
     }

--- a/openwisp_utils/releaser/version.py
+++ b/openwisp_utils/releaser/version.py
@@ -111,7 +111,7 @@ def _bump_ansible_version(content, new_version, version_path):
     )
 
 
-def _bump_version_file_version(content, new_version, version_path):
+def _bump_generic_version(content, new_version, version_path):
     """Handles version bumping for packages using a root VERSION file."""
     return f"{new_version}\n"
 
@@ -122,7 +122,7 @@ VERSION_BUMP_HANDLERS = {
     "npm": _bump_npm_version,
     "docker": _bump_docker_version,
     "ansible": _bump_ansible_version,
-    "version_file": _bump_version_file_version,
+    "generic": _bump_generic_version,
 }
 
 

--- a/openwisp_utils/releaser/version.py
+++ b/openwisp_utils/releaser/version.py
@@ -111,8 +111,8 @@ def _bump_ansible_version(content, new_version, version_path):
     )
 
 
-def _bump_openwrt_version(content, new_version, version_path):
-    """Handles version bumping for OpenWRT packages."""
+def _bump_version_file_version(content, new_version, version_path):
+    """Handles version bumping for packages using a root VERSION file."""
     return f"{new_version}\n"
 
 
@@ -122,7 +122,7 @@ VERSION_BUMP_HANDLERS = {
     "npm": _bump_npm_version,
     "docker": _bump_docker_version,
     "ansible": _bump_ansible_version,
-    "openwrt": _bump_openwrt_version,
+    "version_file": _bump_version_file_version,
 }
 
 


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

Replaces the `.luacheckrc`-based OpenWrt package type detection with a generic `VERSION` file fallback. When no other package type indicator (`setup.py`, `package.json`, `docker-compose.yml`, `.ansible-lint`) is found, a root `VERSION` file triggers `version_file` package type detection.

- Removed `.luacheckrc`-based OpenWrt detection — `.luacheckrc` alone no longer triggers any package type
- Added generic `version_file` package type as a last-resort fallback (does not override other package types)
- Renamed internal handlers from `openwrt` to `version_file` for clarity
- Updated tests and added coverage for: VERSION file fallback behavior, non-interference with other package types, graceful handling of malformed versions, and absence of false positives from `.luacheckrc`