### PR TITLE
[tests] Added `get_browser_errors` to `SeleniumTestMixin`

### DIFF
--- a/docs/developer/test-utilities.rst
+++ b/docs/developer/test-utilities.rst
@@ -299,6 +299,24 @@ Logs into the Django admin dashboard.
 - Defaults to using ``admin`` / ``password`` credentials.
 - Navigates to ``/admin/login/`` and fills in the login form.
 
+``get_browser_logs(driver=None)``
++++++++++++++++++++++++++++++++++
+
+Returns all browser console logs captured for the current page.
+
+This includes ``INFO``, ``WARNING`` and ``SEVERE`` entries, so tests which
+only need to assert the absence of JavaScript errors should prefer
+``get_browser_errors()``.
+
+``get_browser_errors(driver=None)``
++++++++++++++++++++++++++++++++++++
+
+Returns relevant ``SEVERE`` browser console entries only.
+
+This helper filters known Firefox internal messages emitted in headless
+environments, for example ``BackupService.sys.mjs``. Use this method when
+a test needs to assert that a page did not emit JavaScript errors.
+
 ``find_element(by, value, timeout=2, driver=None, wait_for='visibility')``
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/openwisp_utils/tests/selenium.py
+++ b/openwisp_utils/tests/selenium.py
@@ -43,6 +43,11 @@ class SeleniumTestMixin:
     retry_delay = 0
     retry_successes_required = 2
     retry_threshold = None
+    ignored_browser_log_messages = (
+        "BackupService.sys.mjs",
+        "PrivateBrowsingUtils.sys.mjs",
+        "PathUtils.join: PathUtils does not support empty paths",
+    )
     _db_conn_lock = threading.RLock()
     _db_conn_serialized = False
 
@@ -311,6 +316,17 @@ class SeleniumTestMixin:
             self._flush_firefox_console_logs(driver)
             return list(driver._console_logs)
         return driver.get_log("browser")
+
+    def get_browser_errors(self, driver=None):
+        return [
+            log
+            for log in self.get_browser_logs(driver=driver)
+            if log.get("level") == "SEVERE"
+            if not any(
+                ignored_message in log.get("message", "")
+                for ignored_message in self.ignored_browser_log_messages
+            )
+        ]
 
     def _flush_firefox_console_logs(self, driver, timeout=2):
         """Wait for pending BiDi console messages to be delivered.

--- a/tests/test_project/tests/test_selenium.py
+++ b/tests/test_project/tests/test_selenium.py
@@ -919,6 +919,25 @@ class TestFirefoxSeleniumHelpers(SeleniumTestMixin, ChannelsLiveServerTestCase):
             self.get_browser_logs(), [{"level": "INFO", "message": "test"}]
         )
 
+    def test_get_browser_errors(self):
+        self.web_driver._console_logs.extend(
+            [
+                {
+                    "level": "SEVERE",
+                    "message": "resource:///modules/backup/BackupService.sys.mjs",
+                },
+                {
+                    "level": "SEVERE",
+                    "message": "TypeError: application error",
+                },
+                {"level": "INFO", "message": "expected lifecycle log"},
+            ]
+        )
+        self.assertEqual(
+            self.get_browser_errors(),
+            [{"level": "SEVERE", "message": "TypeError: application error"}],
+        )
+
     def test_get_browser_logs_captures_page_load_logs(self):
         # Logs emitted during page load (before readyState === "complete") must
         # be captured too; this is what distinguishes the BiDi capture from a


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Minor addition, doesn't require an issue.

## Description of Changes

Added `get_browser_errors` to `SeleniumTestMixin`, which only returns browser errors flagged as severe, used in selenium tests.