### PR TITLE
[ci] Flag invalid pull requests that do not reference validate #709

### DIFF
--- a/.github/actions/bot-autoassign/base.py
+++ b/.github/actions/bot-autoassign/base.py
@@ -2,6 +2,14 @@ import os
 
 from github import Github
 
+MAINTAINER_ROLES = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+DEFAULT_EXCLUDE_PR_AUTHORS = "dependabot[bot]"
+REQUIRED_CONTRIBUTOR_PROJECTS = (
+    "OpenWISP Contributor's Board",
+    "OpenWISP Priorities for next releases",
+)
+INVALID_ISSUE_LABELS = frozenset({"invalid", "wontfix"})
+
 
 class GitHubBot:
     def __init__(self):
@@ -9,6 +17,11 @@ class GitHubBot:
         self.repository_name = os.environ.get("REPOSITORY")
         self.event_name = os.environ.get("GITHUB_EVENT_NAME")
         self.event_payload = None
+        bot_username = os.environ.get("BOT_USERNAME", "openwisp-companion")
+        self.bot_username = bot_username
+        self.bot_login = (
+            bot_username if bot_username.endswith("[bot]") else f"{bot_username}[bot]"
+        )
 
         if self.github_token and self.repository_name:
             try:
@@ -25,3 +38,251 @@ class GitHubBot:
 
     def load_event_payload(self, event_payload):
         self.event_payload = event_payload
+
+    @staticmethod
+    def _normalize_project_title(title: str) -> str:
+        """Normalize project titles for stable comparisons."""
+        return " ".join(title.replace("\u2019", "'").split()).strip()
+
+    @classmethod
+    def _project_title_key(cls, title: str) -> str:
+        """Loose match key: casefold + ignore apostrophes."""
+        normalized = cls._normalize_project_title(title).casefold()
+        return normalized.replace("'", "")
+
+    def get_issue_projects(self, owner, repo_name, issue_number):
+        query = """
+        query($owner: String!, $repo: String!, $issueNumber: Int!) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $issueNumber) {
+              projectItems(first: 10) {
+                nodes {
+                  project {
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        variables = {"owner": owner, "repo": repo_name, "issueNumber": issue_number}
+        headers, result = self.github.requester.graphql_query(query, variables)
+        print(f"DEBUG: Raw GraphQL response: {result}")
+
+        if "errors" in result:
+            raise ValueError(f"GraphQL API Permission Error: {result['errors']}")
+
+        repo_data = result.get("data", {}).get("repository")
+        if not repo_data:
+            raise ValueError(
+                f"GraphQL could not access repository {owner}/{repo_name}; "
+                "possible GitHub API or permission error"
+            )
+        issue_node = repo_data.get("issue")
+        if issue_node is None:
+            raise ValueError(
+                f"GraphQL could not access issue {owner}/{repo_name}#{issue_number}; "
+                "possible GitHub API or permission error"
+            )
+        project_items = issue_node.get("projectItems")
+        if project_items is None:
+            raise ValueError(
+                f"GraphQL could not read project assignments for "
+                f"{owner}/{repo_name}#{issue_number}; "
+                "possible GitHub API or permission error"
+            )
+        nodes = project_items.get("nodes") or []
+        projects = []
+        for node in nodes:
+            if not node:
+                continue
+            project = node.get("project") or {}
+            title = project.get("title")
+            if title:
+                projects.append(self._normalize_project_title(title))
+        return projects
+
+    def validate_pr_issues(self, pr):
+        """Validate if a pull request is from an exempt user or references a validated issue."""
+        if not self.github or not self.repository_name:
+            print("GitHub client or repository name not initialized")
+            return False
+
+        pr_author = (
+            pr.user.login
+            if pr.user and isinstance(getattr(pr.user, "login", None), str)
+            else ""
+        )
+
+        exclude_authors_env = os.environ.get(
+            "EXCLUDE_PR_AUTHORS", DEFAULT_EXCLUDE_PR_AUTHORS
+        )
+        excluded_authors = [
+            auth.strip() for auth in exclude_authors_env.split(",") if auth.strip()
+        ]
+        if pr_author in excluded_authors:
+            print(f"Author {pr_author} is in the exclude list. Proceeding.")
+            return True
+
+        author_association = str(getattr(pr, "author_association", "") or "")
+        if author_association in MAINTAINER_ROLES:
+            print(
+                f"Author {pr_author} is exempt due to association: "
+                f"{author_association}. Proceeding."
+            )
+            return True
+
+        from utils import extract_all_linked_issues
+
+        pr_body = pr.body if isinstance(pr.body, str) else ""
+        linked_issues = extract_all_linked_issues(pr_body, self.repository_name)
+        if not linked_issues:
+            print("No linked issues found in PR body for external contributor.")
+            return False
+
+        current_org = self.repository_name.split("/")[0].lower()
+        required_projects = {
+            self._project_title_key(p) for p in REQUIRED_CONTRIBUTOR_PROJECTS
+        }
+
+        for owner, repo_name, issue_number in linked_issues:
+            if owner.lower() != current_org:
+                print(
+                    f"Issue {owner}/{repo_name}#{issue_number} does not belong "
+                    f"to organization {current_org}, skipping validation."
+                )
+                continue
+
+            try:
+                from github import GithubException
+
+                target_repo = self.github.get_repo(f"{owner}/{repo_name}")
+                issue = target_repo.get_issue(issue_number)
+            except Exception as e:
+                if isinstance(e, GithubException) and e.status == 404:
+                    print(
+                        f"Issue {owner}/{repo_name}#{issue_number} not found, skipping validation."
+                    )
+                    continue
+                print(f"Error fetching issue {owner}/{repo_name}#{issue_number}: {e}")
+                raise
+
+            if issue.pull_request:
+                print(
+                    f"Reference {owner}/{repo_name}#{issue_number} is a pull request, skipping validation."
+                )
+                continue
+
+            if issue.state != "open":
+                print(
+                    f"Issue {owner}/{repo_name}#{issue_number} is not open, skipping validation."
+                )
+                continue
+
+            issue_labels = [label.name.lower() for label in issue.labels]
+            valid_labels = [
+                lbl for lbl in issue_labels if lbl not in INVALID_ISSUE_LABELS
+            ]
+            if not valid_labels:
+                print(
+                    f"Issue {owner}/{repo_name}#{issue_number} has no valid labels, skipping validation."
+                )
+                continue
+            if any(lbl in INVALID_ISSUE_LABELS for lbl in issue_labels):
+                print(
+                    f"Issue {owner}/{repo_name}#{issue_number} contains "
+                    "invalid/wontfix label, skipping validation."
+                )
+                continue
+
+            try:
+                projects = self.get_issue_projects(owner, repo_name, issue_number)
+            except Exception as e:
+                print(
+                    f"Error fetching projects for issue {owner}/{repo_name}#{issue_number}: {e}"
+                )
+                raise
+
+            print(
+                f"DEBUG: Raw projects for {owner}/{repo_name}#{issue_number}: {projects}"
+            )
+            project_keys = [self._project_title_key(p) for p in projects]
+            print(f"DEBUG: Normalized project keys: {project_keys}")
+            print(f"DEBUG: Required project keys: {required_projects}")
+
+            has_valid_project = any(key in required_projects for key in project_keys)
+            if has_valid_project:
+                print(
+                    f"Issue {owner}/{repo_name}#{issue_number} is validated. PR is valid."
+                )
+                return True
+            else:
+                print(
+                    f"Issue {owner}/{repo_name}#{issue_number} is not assigned "
+                    f"to any required project (found: {projects or 'none'}), "
+                    "skipping validation."
+                )
+
+        return False
+
+    def get_bot_comment(self, pr, comment_type, after_date=None, issue_comments=None):
+        """Get the comment of this bot with the given marker if it exists.
+
+        If ``after_date`` is provided, only considers comments posted after that date.
+        """
+        try:
+            if issue_comments is None:
+                issue_comments = list(pr.get_issue_comments())
+            marker = f"<!-- bot:{comment_type} -->"
+            for comment in issue_comments:
+                if (
+                    comment.user
+                    and comment.user.login == self.bot_login
+                    and marker in comment.body
+                ):
+                    if after_date and comment.created_at <= after_date:
+                        continue
+                    return comment
+            return None
+        except Exception as e:
+            print(f"Error getting bot comment for PR #{pr.number}: {e}")
+            return None
+
+    def has_bot_comment(self, pr, comment_type, after_date=None, issue_comments=None):
+        """Check if PR already has a specific type of bot comment.
+
+        Uses HTML markers. If ``after_date`` is provided,
+        only considers comments posted after that date.
+        """
+        return bool(self.get_bot_comment(pr, comment_type, after_date, issue_comments))
+
+    def get_invalid_unvalidated_issue_comment(self, pr_author):
+        """Returns the comment body warning that the PR is invalid/unvalidated."""
+        greeting = f"Hi @{pr_author},\n\n" if pr_author else "Hi,\n\n"
+        return (
+            "<!-- bot:invalid_unvalidated_issue -->\n\n"
+            f"{greeting}"
+            "Thank you for your interest in contributing to OpenWISP.\n\n"
+            "This pull request has been flagged because external contributors "
+            "must target an issue validated by maintainers before requesting "
+            "review.\n\n"
+            "Please link this pull request to a validated issue by adding "
+            "`Fixes #ISSUE_NUMBER`, `Closes #ISSUE_NUMBER`, or "
+            "`Related to #ISSUE_NUMBER` to the pull request description. "
+            "The issue may be in this repository or another OpenWISP "
+            "repository.\n\n"
+            "If there is no validated issue yet, please open one first and wait "
+            "for maintainer validation before continuing with this pull "
+            "request.\n\n"
+            "An issue is considered validated when it is open, has an appropriate "
+            "label other than `invalid` or `wontfix`, and is assigned to one of "
+            "the OpenWISP contributor project boards mentioned in the "
+            "contributing guidelines.\n\n"
+            "Please see the OpenWISP policy on unsolicited and AI-assisted "
+            "contributions:\n"
+            "https://openwisp.io/docs/dev/general/code-of-conduct.html\n\n"
+            "If this is not resolved within 24 hours, this pull request "
+            "will be closed automatically. "
+            "Thank you for your understanding."
+        )

--- a/.github/actions/bot-autoassign/base.py
+++ b/.github/actions/bot-autoassign/base.py
@@ -5,6 +5,7 @@ from utils import extract_all_linked_issues
 
 MAINTAINER_ROLES = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 DEFAULT_EXCLUDE_PR_AUTHORS = "dependabot[bot]"
+MAX_VALIDATION_ISSUES = 10
 # Stable ProjectV2 node IDs for the OpenWISP contributor boards.
 # These IDs never change even if a board is renamed.
 REQUIRED_CONTRIBUTOR_PROJECT_IDS = frozenset(
@@ -162,8 +163,13 @@ class GitHubBot:
         if not linked_issues:
             print("No linked issues found in PR body for external contributor.")
             return False
+        if len(linked_issues) > MAX_VALIDATION_ISSUES:
+            print(
+                f"Found {len(linked_issues)} issue references, validating first "
+                f"{MAX_VALIDATION_ISSUES} to avoid rate limits"
+            )
         current_org = self.repository_name.split("/")[0].lower()
-        for owner, repo_name, issue_number in linked_issues:
+        for owner, repo_name, issue_number in linked_issues[:MAX_VALIDATION_ISSUES]:
             if owner.lower() != current_org:
                 print(
                     f"Issue {owner}/{repo_name}#{issue_number} does not belong "

--- a/.github/actions/bot-autoassign/base.py
+++ b/.github/actions/bot-autoassign/base.py
@@ -19,7 +19,7 @@ INVALID_ISSUE_LABELS = frozenset({"invalid", "wontfix"})
 class GitHubBot:
     def __init__(self):
         self.github_token = os.environ.get("GITHUB_TOKEN")
-        self.github_validation_token = os.environ.get("GITHUB_VALIDATION_TOKEN")
+        self.github_validation_token = os.environ.get("VALIDATION_GITHUB_TOKEN")
         self.repository_name = os.environ.get("REPOSITORY")
         self.event_name = os.environ.get("GITHUB_EVENT_NAME")
         self.event_payload = None
@@ -49,7 +49,7 @@ class GitHubBot:
                 self.github_validation = None
         else:
             print(
-                "Warning: GITHUB_VALIDATION_TOKEN env var not set, falling back to GITHUB_TOKEN"
+                "Warning: VALIDATION_GITHUB_TOKEN env var not set, falling back to GITHUB_TOKEN"
             )
             self.github_validation = self.github
 

--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -1,4 +1,3 @@
-import os
 import re
 
 from base import GitHubBot
@@ -14,9 +13,6 @@ from utils import (
 
 
 class IssueAssignmentBot(GitHubBot):
-    def __init__(self):
-        super().__init__()
-        self.bot_username = os.environ.get("BOT_USERNAME", "openwisp-companion")
 
     def is_bot_assign_command(self, comment_body):
         if not comment_body:
@@ -440,15 +436,40 @@ class IssueAssignmentBot(GitHubBot):
             if not all([pr_number, pr_author]):
                 print("Missing required PR data")
                 return False
-            if action in ["opened", "reopened"]:
-                self.auto_assign_issues_from_pr(pr_number, pr_author, pr_body)
-                # We consider the event handled even if no issues were linked
-                return True
-            elif action == "closed":
+            if action == "closed":
                 if pr.get("merged", False):
                     print(f"PR #{pr_number} was merged, keeping issue assignments")
                 else:
                     self.unassign_issues_from_pr(pr_body, pr_author)
+                return True
+
+            if action in ["opened", "reopened", "edited", "ready_for_review"]:
+                self.auto_assign_issues_from_pr(pr_number, pr_author, pr_body)
+                pr_obj = self.repo.get_pull(pr_number)
+                is_valid = self.validate_pr_issues(pr_obj)
+                labels_lower = set()
+                try:
+                    labels_lower = {label.name.lower() for label in pr_obj.labels}
+                except (TypeError, AttributeError):
+                    pass
+
+                if is_valid:
+                    if "invalid" in labels_lower:
+                        pr_obj.remove_from_labels("invalid")
+                        print(f"Removed 'invalid' label from PR #{pr_number}")
+                else:
+                    if "invalid" not in labels_lower:
+                        pr_obj.add_to_labels("invalid")
+                        print(f"Added 'invalid' label to PR #{pr_number}")
+
+                    if not self.has_bot_comment(pr_obj, "invalid_unvalidated_issue"):
+                        comment_body = self.get_invalid_unvalidated_issue_comment(
+                            pr_author
+                        )
+                        pr_obj.create_issue_comment(comment_body)
+                        print(
+                            f"Posted unvalidated issue warning comment on PR #{pr_number}"
+                        )
                 return True
             print(f"PR action '{action}' not handled")
             return True

--- a/.github/actions/bot-autoassign/stale_pr_bot.py
+++ b/.github/actions/bot-autoassign/stale_pr_bot.py
@@ -1,16 +1,16 @@
-import os
 import time
 from datetime import datetime, timezone
 
-from base import GitHubBot
+from base import MAINTAINER_ROLES, GitHubBot
 from utils import (
     extract_linked_issues,
     get_valid_linked_issues,
     unassign_linked_issues_helper,
 )
 
-# GitHub author_association values that represent project maintainers.
-MAINTAINER_ROLES = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+class ValidationAPIError(Exception):
+    pass
 
 
 class StalePRBot(GitHubBot):
@@ -19,10 +19,6 @@ class StalePRBot(GitHubBot):
         self.DAYS_BEFORE_STALE_WARNING = 7
         self.DAYS_BEFORE_UNASSIGN = 14
         self.DAYS_BEFORE_FINAL_FOLLOWUP = 60
-        bot_username = os.environ.get("BOT_USERNAME", "openwisp-companion")
-        self.bot_login = (
-            bot_username if bot_username.endswith("[bot]") else f"{bot_username}[bot]"
-        )
 
     @staticmethod
     def _commit_activity_date_for_author(commit, pr_author):
@@ -194,28 +190,6 @@ class StalePRBot(GitHubBot):
             ),
             default=None,
         )
-
-    def has_bot_comment(self, pr, comment_type, after_date=None, issue_comments=None):
-        """Check if this bot has already posted a comment with the given
-        marker. If ``after_date`` is set, only later comments count.
-        """
-        try:
-            if issue_comments is None:
-                issue_comments = list(pr.get_issue_comments())
-            marker = f"<!-- bot:{comment_type} -->"
-            for comment in issue_comments:
-                if (
-                    comment.user
-                    and comment.user.login == self.bot_login
-                    and marker in comment.body
-                ):
-                    if after_date and comment.created_at <= after_date:
-                        continue
-                    return True
-            return False
-        except Exception as e:
-            print(f"Error checking bot comments for PR #{pr.number}: {e}")
-            return False
 
     def unassign_linked_issues(self, pr):
         pr_author = pr.user.login if pr.user else None
@@ -395,6 +369,63 @@ class StalePRBot(GitHubBot):
             for pr in open_prs:
                 pr_count += 1
                 try:
+                    pr_labels = [label.name.lower() for label in pr.labels]
+                    if "invalid" in pr_labels:
+                        try:
+                            is_valid = self.validate_pr_issues(pr)
+                        except Exception as e:
+                            print(
+                                f"Critical issue-project verification error on PR #{pr.number}: {e}"
+                            )
+                            raise ValidationAPIError(e)
+
+                        if is_valid:
+                            pr.remove_from_labels("invalid")
+                            print(
+                                f"PR #{pr.number} is now valid. Removed 'invalid' label."
+                            )
+                        else:
+                            comments = list(pr.get_issue_comments())
+                            warning_comment = self.get_bot_comment(
+                                pr, "invalid_unvalidated_issue", issue_comments=comments
+                            )
+                            if warning_comment:
+                                now = datetime.now(timezone.utc)
+                                if (
+                                    now - warning_comment.created_at
+                                ).total_seconds() >= 24 * 3600:
+                                    close_message = (
+                                        "<!-- bot:invalid_unvalidated_issue_closed -->\n\n"
+                                        "This pull request has been automatically closed because it has "
+                                        "been flagged as invalid (not referencing a validated issue) "
+                                        "for more than 24 hours."
+                                    )
+                                    try:
+                                        pr.create_issue_comment(close_message)
+                                    except Exception as comment_error:
+                                        print(
+                                            f"Warning: Could not post close comment on PR "
+                                            f"#{pr.number}: {comment_error}"
+                                        )
+                                    pr.edit(state="closed")
+                                    print(
+                                        f"Closed PR #{pr.number} automatically after 24 hours."
+                                    )
+                                    processed_count += 1
+                            else:
+                                pr_author = pr.user.login if pr.user else None
+                                comment_body = (
+                                    self.get_invalid_unvalidated_issue_comment(
+                                        pr_author
+                                    )
+                                )
+                                pr.create_issue_comment(comment_body)
+                                print(
+                                    f"Posted missing warning comment on PR #{pr.number}"
+                                )
+                                processed_count += 1
+                        continue
+
                     all_reviews = list(pr.get_reviews())
                     last_changes_requested = self.get_last_changes_requested(
                         pr, all_reviews
@@ -479,6 +510,8 @@ class StalePRBot(GitHubBot):
                             posted_stale_this_run = True
                         if action(pr, days_inactive):
                             processed_count += 1
+                except ValidationAPIError:
+                    raise
                 except Exception as e:
                     print(f"Error processing PR #{pr.number}: {e}")
                     continue

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -885,3 +885,295 @@ class TestHandleIssueCommentBotCommand:
         )
         assert bot.handle_issue_comment()
         bot_env["repo"].get_issue.assert_not_called()
+
+
+class TestExtractAllLinkedIssues:
+    @pytest.mark.parametrize(
+        "pr_body,expected",
+        [
+            ("Fixes #123", [("openwisp", "openwisp-utils", 123)]),
+            (
+                "Fixes openwisp/openwisp-utils#709",
+                [("openwisp", "openwisp-utils", 709)],
+            ),
+            (
+                "Fixes https://github.com/openwisp/openwisp-utils/issues/709",
+                [("openwisp", "openwisp-utils", 709)],
+            ),
+            ("Related to #99", [("openwisp", "openwisp-utils", 99)]),
+            (
+                "Closes #456 and resolves #789",
+                [
+                    ("openwisp", "openwisp-utils", 456),
+                    ("openwisp", "openwisp-utils", 789),
+                ],
+            ),
+            ("Closes openwisp-utils#42", []),
+            ("", []),
+            (None, []),
+        ],
+    )
+    def test_extract_all_linked_issues(self, pr_body, expected, bot_env):
+        from utils import extract_all_linked_issues
+
+        assert extract_all_linked_issues(pr_body, "openwisp/openwisp-utils") == expected
+
+
+class TestPRValidation:
+    def test_get_issue_projects_success(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.github.requester.graphql_query.return_value = (
+            {},
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "projectItems": {
+                                "nodes": [
+                                    {
+                                        "project": {
+                                            "title": "OpenWISP Contributor's Board"
+                                        }
+                                    },
+                                    {"project": {"title": "Some Other Board"}},
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        projects = bot.get_issue_projects("openwisp", "openwisp-utils", 123)
+        assert projects == ["OpenWISP Contributor's Board", "Some Other Board"]
+        bot.github.requester.graphql_query.assert_called_once()
+
+    def test_get_issue_projects_single_project(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.github.requester.graphql_query.return_value = (
+            {},
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "projectItems": {
+                                "nodes": [
+                                    {"project": {"title": "Classic Project Board"}},
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        projects = bot.get_issue_projects("openwisp", "openwisp-utils", 123)
+        assert projects == ["Classic Project Board"]
+
+    def test_get_issue_projects_graphql_error(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.github.requester.graphql_query.side_effect = GithubException(
+            400, {"errors": [{"message": "Some error"}]}, {}
+        )
+        with pytest.raises(GithubException):
+            bot.get_issue_projects("openwisp", "openwisp-utils", 123)
+
+    def test_get_issue_projects_null_project_items(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.github.requester.graphql_query.return_value = (
+            {},
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "projectItems": None,
+                        }
+                    }
+                }
+            },
+        )
+        with pytest.raises(ValueError, match="could not read project assignments"):
+            bot.get_issue_projects("openwisp", "openwisp-utils", 123)
+
+    def test_get_issue_projects_null_issue(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.github.requester.graphql_query.return_value = (
+            {},
+            {"data": {"repository": {"issue": None}}},
+        )
+        with pytest.raises(ValueError, match="could not access issue"):
+            bot.get_issue_projects("openwisp", "openwisp-utils", 123)
+
+    def test_validate_pr_issues_excluded_author(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "dependabot[bot]"
+        assert bot.validate_pr_issues(mock_pr)
+
+    def test_validate_pr_issues_exempt_association(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "some-member"
+        mock_pr.author_association = "MEMBER"
+        assert bot.validate_pr_issues(mock_pr)
+
+    def test_validate_pr_issues_no_issues(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "No references here"
+        assert not bot.validate_pr_issues(mock_pr)
+
+    def test_validate_pr_issues_cross_org_issue(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Fixes otherorg/repo#12"
+        assert not bot.validate_pr_issues(mock_pr)
+
+    def test_validate_pr_issues_is_pr(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Fixes #12"
+
+        mock_issue = Mock()
+        mock_issue.pull_request = {"url": "..."}
+        bot_env["repo"].get_issue.return_value = mock_issue
+
+        assert not bot.validate_pr_issues(mock_pr)
+
+    def test_validate_pr_issues_closed(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Fixes #12"
+
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.state = "closed"
+        bot_env["repo"].get_issue.return_value = mock_issue
+
+        assert not bot.validate_pr_issues(mock_pr)
+
+    def test_validate_pr_issues_invalid_labels(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Fixes #12"
+
+        # Test case 1: No labels
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.state = "open"
+        mock_issue.labels = []
+        bot_env["repo"].get_issue.return_value = mock_issue
+        assert not bot.validate_pr_issues(mock_pr)
+
+        # Test case 2: Has wontfix/invalid labels
+        label_wontfix = Mock()
+        label_wontfix.name = "wontfix"
+        mock_issue.labels = [label_wontfix]
+        assert not bot.validate_pr_issues(mock_pr)
+
+        # Test case 3: Has a mix of valid and invalid/wontfix labels
+        label_bug = Mock()
+        label_bug.name = "bug"
+        mock_issue.labels = [label_bug, label_wontfix]
+        assert not bot.validate_pr_issues(mock_pr)
+
+    def test_validate_pr_issues_not_in_project(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Fixes #12"
+
+        label_bug = Mock()
+        label_bug.name = "bug"
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.state = "open"
+        mock_issue.labels = [label_bug]
+        bot_env["repo"].get_issue.return_value = mock_issue
+
+        with patch.object(
+            bot, "get_issue_projects", return_value=["Some Other Project"]
+        ):
+            assert not bot.validate_pr_issues(mock_pr)
+
+    def test_validate_pr_issues_fully_valid(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Fixes #12"
+
+        label_bug = Mock()
+        label_bug.name = "bug"
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.state = "open"
+        mock_issue.labels = [label_bug]
+        bot_env["repo"].get_issue.return_value = mock_issue
+
+        with patch.object(
+            bot, "get_issue_projects", return_value=["OpenWISP Contributor's Board"]
+        ):
+            assert bot.validate_pr_issues(mock_pr)
+
+    def test_handle_pull_request_invalid_label_and_comment(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.event_name = "pull_request_target"
+        bot.load_event_payload(
+            {
+                "action": "opened",
+                "pull_request": {
+                    "number": 100,
+                    "user": {"login": "testuser"},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+
+        mock_pr_obj = Mock()
+        mock_pr_obj.labels = []
+        bot_env["repo"].get_pull.return_value = mock_pr_obj
+
+        with patch.object(bot, "validate_pr_issues", return_value=False), patch.object(
+            bot, "has_bot_comment", return_value=False
+        ):
+            assert bot.handle_pull_request()
+            mock_pr_obj.add_to_labels.assert_called_once_with("invalid")
+            mock_pr_obj.create_issue_comment.assert_called_once()
+            assert (
+                "invalid_unvalidated_issue"
+                in mock_pr_obj.create_issue_comment.call_args[0][0].lower()
+            )
+
+    def test_handle_pull_request_valid_removes_label(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.event_name = "pull_request_target"
+        bot.load_event_payload(
+            {
+                "action": "edited",
+                "pull_request": {
+                    "number": 100,
+                    "user": {"login": "testuser"},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+
+        mock_label = Mock()
+        mock_label.name = "invalid"
+        mock_pr_obj = Mock()
+        mock_pr_obj.labels = [mock_label]
+        bot_env["repo"].get_pull.return_value = mock_pr_obj
+
+        with patch.object(bot, "validate_pr_issues", return_value=True):
+            assert bot.handle_pull_request()
+            mock_pr_obj.remove_from_labels.assert_called_once_with("invalid")

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -10,6 +10,7 @@ from github import GithubException  # noqa: E402
 
 try:
     from issue_assignment_bot import IssueAssignmentBot  # noqa: E402
+    from utils import extract_all_linked_issues  # noqa: E402
 except ImportError:
     IssueAssignmentBot = None
 
@@ -23,7 +24,7 @@ pytestmark = pytest.mark.skipif(
 def bot_env(monkeypatch):
     """Set up environment and mock GitHub client for all tests."""
     monkeypatch.setenv("GITHUB_TOKEN", "test_token")
-    monkeypatch.setenv("GITHUB_VALIDATION_TOKEN", "test_validation_token")
+    monkeypatch.setenv("VALIDATION_GITHUB_TOKEN", "test_validation_token")
     monkeypatch.setenv("REPOSITORY", "openwisp/openwisp-utils")
     monkeypatch.setenv("GITHUB_EVENT_NAME", "issue_comment")
     monkeypatch.setattr("utils.time.sleep", lambda _seconds: None)
@@ -952,7 +953,6 @@ class TestExtractAllLinkedIssues:
         ],
     )
     def test_extract_all_linked_issues(self, pr_body, expected, bot_env):
-        from utils import extract_all_linked_issues
 
         assert extract_all_linked_issues(pr_body, "openwisp/openwisp-utils") == expected
 
@@ -1201,7 +1201,78 @@ class TestPRValidation:
         ):
             assert bot.validate_pr_issues(mock_pr)
 
+    def test_client_segregation_mutations_vs_validation(self, bot_env):
+        """Proves cross-repository validation uses the read-only validation client,
+        while all mutations use the repository-scoped write client.
+        """
+        bot = IssueAssignmentBot()
+        bot.event_name = "pull_request_target"
+
+        # Mocks for validation (reads)
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.state = "open"
+        label_bug = Mock()
+        label_bug.name = "bug"
+        mock_issue.labels = [label_bug]
+        bot_env["repo_validation"].get_issue.return_value = mock_issue
+        bot.github_validation.requester.graphql_query.return_value = (
+            {},
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "projectItems": {
+                                "nodes": [{"project": {"id": "PVT_kwDOABGNI84Amkl7"}}]
+                            }
+                        }
+                    }
+                }
+            },
+        )
+
+        # Mocks for mutations (writes)
+        mock_pr = Mock()
+        mock_pr.number = 12
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Fixes #123"
+        invalid_label = Mock()
+        invalid_label.name = "invalid"
+        mock_pr.labels = [invalid_label]
+        bot_env["repo"].get_pull.return_value = mock_pr
+
+        # Execute handler
+        bot.load_event_payload(
+            {
+                "action": "opened",
+                "pull_request": {
+                    "number": 12,
+                    "merged": False,
+                    "user": {"login": "external-contributor"},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+        bot.handle_pull_request()
+
+        # Assert Reads used VALIDATION client
+        bot_env["github_validation"].get_repo.assert_any_call("openwisp/openwisp-utils")
+        bot_env["repo_validation"].get_issue.assert_called_once_with(123)
+        bot.github_validation.requester.graphql_query.assert_called_once()
+
+        # Assert Writes used WRITE client (bot_env["repo"] / bot_env["github"])
+        bot_env["repo"].get_pull.assert_called_once_with(12)
+        mock_pr.remove_from_labels.assert_called_once_with("invalid")
+
+        # Ensure validation client is strictly read-only in this flow (no label/edit calls)
+        assert (
+            not hasattr(bot_env["repo_validation"], "remove_from_labels")
+            or not bot_env["repo_validation"].remove_from_labels.called
+        )
+
     def test_handle_pull_request_invalid_label_and_comment(self, bot_env):
+
         bot = IssueAssignmentBot()
         bot.event_name = "pull_request_target"
         bot.load_event_payload(

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -953,7 +953,6 @@ class TestExtractAllLinkedIssues:
         ],
     )
     def test_extract_all_linked_issues(self, pr_body, expected, bot_env):
-
         assert extract_all_linked_issues(pr_body, "openwisp/openwisp-utils") == expected
 
 
@@ -1110,6 +1109,20 @@ class TestPRValidation:
         mock_pr.body = "No references here"
         assert not bot.validate_pr_issues(mock_pr)
 
+    def test_validate_pr_issues_limits_linked_issues(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = " ".join(f"Fixes #{number}" for number in range(1, 12))
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.state = "open"
+        mock_issue.labels = []
+        bot_env["repo_validation"].get_issue.return_value = mock_issue
+        assert not bot.validate_pr_issues(mock_pr)
+        assert bot_env["repo_validation"].get_issue.call_count == 10
+
     def test_validate_pr_issues_cross_org_issue(self, bot_env):
         bot = IssueAssignmentBot()
         mock_pr = Mock()
@@ -1126,7 +1139,7 @@ class TestPRValidation:
         mock_pr.body = "Fixes #12"
         mock_issue = Mock()
         mock_issue.pull_request = {"url": "..."}
-        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo_validation"].get_issue.return_value = mock_issue
         assert not bot.validate_pr_issues(mock_pr)
 
     def test_validate_pr_issues_closed(self, bot_env):
@@ -1138,7 +1151,7 @@ class TestPRValidation:
         mock_issue = Mock()
         mock_issue.pull_request = None
         mock_issue.state = "closed"
-        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo_validation"].get_issue.return_value = mock_issue
         assert not bot.validate_pr_issues(mock_pr)
 
     def test_validate_pr_issues_invalid_labels(self, bot_env):
@@ -1152,7 +1165,7 @@ class TestPRValidation:
         mock_issue.pull_request = None
         mock_issue.state = "open"
         mock_issue.labels = []
-        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo_validation"].get_issue.return_value = mock_issue
         assert not bot.validate_pr_issues(mock_pr)
         # Test case 2: Has wontfix/invalid labels
         label_wontfix = Mock()
@@ -1177,7 +1190,7 @@ class TestPRValidation:
         mock_issue.pull_request = None
         mock_issue.state = "open"
         mock_issue.labels = [label_bug]
-        bot_env["repo"].get_issue.return_value = mock_issue
+        bot_env["repo_validation"].get_issue.return_value = mock_issue
         with patch.object(
             bot, "get_issue_projects", return_value=["Some Other Project"]
         ):
@@ -1207,7 +1220,6 @@ class TestPRValidation:
         """
         bot = IssueAssignmentBot()
         bot.event_name = "pull_request_target"
-
         # Mocks for validation (reads)
         mock_issue = Mock()
         mock_issue.pull_request = None
@@ -1230,7 +1242,6 @@ class TestPRValidation:
                 }
             },
         )
-
         # Mocks for mutations (writes)
         mock_pr = Mock()
         mock_pr.number = 12
@@ -1241,7 +1252,6 @@ class TestPRValidation:
         invalid_label.name = "invalid"
         mock_pr.labels = [invalid_label]
         bot_env["repo"].get_pull.return_value = mock_pr
-
         # Execute handler
         bot.load_event_payload(
             {
@@ -1255,7 +1265,6 @@ class TestPRValidation:
             }
         )
         bot.handle_pull_request()
-
         # Assert Reads used VALIDATION client
         bot_env["github_validation"].get_repo.assert_any_call("openwisp/openwisp-utils")
         bot_env["repo_validation"].get_issue.assert_called_once_with(123)
@@ -1264,7 +1273,6 @@ class TestPRValidation:
         # Assert Writes used WRITE client (bot_env["repo"] / bot_env["github"])
         bot_env["repo"].get_pull.assert_called_once_with(12)
         mock_pr.remove_from_labels.assert_called_once_with("invalid")
-
         # Ensure validation client is strictly read-only in this flow (no label/edit calls)
         assert (
             not hasattr(bot_env["repo_validation"], "remove_from_labels")
@@ -1272,7 +1280,6 @@ class TestPRValidation:
         )
 
     def test_handle_pull_request_invalid_label_and_comment(self, bot_env):
-
         bot = IssueAssignmentBot()
         bot.event_name = "pull_request_target"
         bot.load_event_payload(

--- a/.github/actions/bot-autoassign/tests/test_stale_pr_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_stale_pr_bot.py
@@ -860,3 +860,91 @@ class TestRun:
         bot.github = None
         bot.repo = None
         assert not bot.run()
+
+
+class TestStalePRBotInvalidCheck:
+    def test_invalid_pr_becomes_valid(self, bot_env):
+        bot = StalePRBot()
+        mock_label = Mock()
+        mock_label.name = "invalid"
+
+        mock_pr = Mock()
+        mock_pr.labels = [mock_label]
+        mock_pr.number = 100
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+
+        with patch.object(bot, "validate_pr_issues", return_value=True):
+            assert bot.process_stale_prs()
+            mock_pr.remove_from_labels.assert_called_once_with("invalid")
+            mock_pr.edit.assert_not_called()
+
+    def test_invalid_pr_still_invalid_under_24h(self, bot_env):
+        bot = StalePRBot()
+        mock_label = Mock()
+        mock_label.name = "invalid"
+
+        mock_pr = Mock()
+        mock_pr.labels = [mock_label]
+        mock_pr.number = 100
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+
+        mock_comment = Mock()
+        mock_comment.user.login = bot.bot_login
+        mock_comment.body = "<!-- bot:invalid_unvalidated_issue --> Warning comment"
+        mock_comment.created_at = datetime.now(timezone.utc)
+        mock_pr.get_issue_comments.return_value = [mock_comment]
+
+        with patch.object(bot, "validate_pr_issues", return_value=False):
+            assert bot.process_stale_prs()
+            mock_pr.remove_from_labels.assert_not_called()
+            mock_pr.edit.assert_not_called()
+
+    def test_invalid_pr_still_invalid_over_24h_closes(self, bot_env):
+        bot = StalePRBot()
+        mock_label = Mock()
+        mock_label.name = "invalid"
+
+        mock_pr = Mock()
+        mock_pr.labels = [mock_label]
+        mock_pr.number = 100
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+
+        mock_comment = Mock()
+        mock_comment.user.login = bot.bot_login
+        mock_comment.body = "<!-- bot:invalid_unvalidated_issue --> Warning comment"
+        from datetime import timedelta
+
+        mock_comment.created_at = datetime.now(timezone.utc) - timedelta(hours=25)
+        mock_pr.get_issue_comments.return_value = [mock_comment]
+
+        with patch.object(bot, "validate_pr_issues", return_value=False):
+            assert bot.process_stale_prs()
+            mock_pr.remove_from_labels.assert_not_called()
+            mock_pr.create_issue_comment.assert_called_once()
+            assert (
+                "automatically closed" in mock_pr.create_issue_comment.call_args[0][0]
+            )
+            mock_pr.edit.assert_called_once_with(state="closed")
+
+    def test_invalid_pr_missing_warning_comment_posts_warning(self, bot_env):
+        bot = StalePRBot()
+        mock_label = Mock()
+        mock_label.name = "invalid"
+
+        mock_pr = Mock()
+        mock_pr.labels = [mock_label]
+        mock_pr.number = 100
+        mock_pr.user.login = "contributor"
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+
+        mock_pr.get_issue_comments.return_value = []
+
+        with patch.object(bot, "validate_pr_issues", return_value=False):
+            assert bot.process_stale_prs()
+            mock_pr.remove_from_labels.assert_not_called()
+            mock_pr.create_issue_comment.assert_called_once()
+            assert (
+                "<!-- bot:invalid_unvalidated_issue -->"
+                in mock_pr.create_issue_comment.call_args[0][0]
+            )
+            mock_pr.edit.assert_not_called()

--- a/.github/actions/bot-autoassign/tests/test_stale_pr_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_stale_pr_bot.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.skipif(
 @pytest.fixture(autouse=True)
 def bot_env(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "test_token")
-    monkeypatch.setenv("GITHUB_VALIDATION_TOKEN", "test_validation_token")
+    monkeypatch.setenv("VALIDATION_GITHUB_TOKEN", "test_validation_token")
     monkeypatch.setenv("REPOSITORY", "openwisp/openwisp-utils")
 
     mock_github = Mock()
@@ -897,6 +897,64 @@ class TestStalePRBotInvalidCheck:
             assert bot.process_stale_prs()
             mock_pr.remove_from_labels.assert_called_once_with("invalid")
             mock_pr.edit.assert_not_called()
+
+    def test_client_segregation_mutations_vs_validation(self, bot_env):
+        """Proves cross-repository validation uses the read-only validation client,
+        while all mutations use the repository-scoped write client.
+        """
+        bot = StalePRBot()
+
+        # Mocks for mutations (writes)
+        mock_label = Mock()
+        mock_label.name = "invalid"
+        mock_pr = Mock()
+        mock_pr.labels = [mock_label]
+        mock_pr.number = 100
+        mock_pr.user.login = "external-contributor"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Fixes #123"
+        bot_env["repo"].get_pulls.return_value = [mock_pr]
+
+        # Mocks for validation (reads)
+        mock_issue = Mock()
+        mock_issue.pull_request = None
+        mock_issue.state = "open"
+        label_bug = Mock()
+        label_bug.name = "bug"
+        mock_issue.labels = [label_bug]
+        bot_env["repo_validation"].get_issue.return_value = mock_issue
+        bot.github_validation.requester.graphql_query.return_value = (
+            {},
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "projectItems": {
+                                "nodes": [{"project": {"id": "PVT_kwDOABGNI84Amkl7"}}]
+                            }
+                        }
+                    }
+                }
+            },
+        )
+
+        # Execute handler
+        assert bot.process_stale_prs()
+
+        # Assert Reads used VALIDATION client
+        bot_env["github_validation"].get_repo.assert_any_call("openwisp/openwisp-utils")
+        bot_env["repo_validation"].get_issue.assert_called_once_with(123)
+        bot.github_validation.requester.graphql_query.assert_called_once()
+
+        # Assert Writes used WRITE client (bot_env["repo"] / bot_env["github"])
+        bot_env["repo"].get_pulls.assert_called_once()
+        mock_pr.remove_from_labels.assert_called_once_with("invalid")
+
+        # Ensure validation client is strictly read-only in this flow (no label/edit calls)
+        assert (
+            not hasattr(bot_env["repo_validation"], "remove_from_labels")
+            or not bot_env["repo_validation"].remove_from_labels.called
+        )
 
     def test_invalid_pr_still_invalid_under_24h(self, bot_env):
         bot = StalePRBot()

--- a/.github/actions/bot-autoassign/tests/test_stale_pr_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_stale_pr_bot.py
@@ -903,7 +903,6 @@ class TestStalePRBotInvalidCheck:
         while all mutations use the repository-scoped write client.
         """
         bot = StalePRBot()
-
         # Mocks for mutations (writes)
         mock_label = Mock()
         mock_label.name = "invalid"
@@ -914,7 +913,6 @@ class TestStalePRBotInvalidCheck:
         mock_pr.author_association = "NONE"
         mock_pr.body = "Fixes #123"
         bot_env["repo"].get_pulls.return_value = [mock_pr]
-
         # Mocks for validation (reads)
         mock_issue = Mock()
         mock_issue.pull_request = None
@@ -937,10 +935,8 @@ class TestStalePRBotInvalidCheck:
                 }
             },
         )
-
         # Execute handler
         assert bot.process_stale_prs()
-
         # Assert Reads used VALIDATION client
         bot_env["github_validation"].get_repo.assert_any_call("openwisp/openwisp-utils")
         bot_env["repo_validation"].get_issue.assert_called_once_with(123)
@@ -949,7 +945,6 @@ class TestStalePRBotInvalidCheck:
         # Assert Writes used WRITE client (bot_env["repo"] / bot_env["github"])
         bot_env["repo"].get_pulls.assert_called_once()
         mock_pr.remove_from_labels.assert_called_once_with("invalid")
-
         # Ensure validation client is strictly read-only in this flow (no label/edit calls)
         assert (
             not hasattr(bot_env["repo_validation"], "remove_from_labels")

--- a/.github/actions/bot-autoassign/utils.py
+++ b/.github/actions/bot-autoassign/utils.py
@@ -110,3 +110,40 @@ def unassign_linked_issues_helper(repo, repository_name, pr_body, pr_author):
         except Exception as e:
             print(f"Error unassigning issue #{issue_number}: {e}")
     return unassigned_issues
+
+
+def extract_all_linked_issues(pr_body, default_repo_full_name):
+    """Extract all linked issues (including cross-repository and URLs).
+
+    Returns a list of tuples: (owner, repo_name, issue_number)
+    """
+    if not pr_body:
+        return []
+    # Pattern to match:
+    # 1. URL: https://github.com/owner/repo/issues/num
+    # 2. owner/repo#num
+    # 3. #num
+    pattern = (
+        r"\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?|relat(?:e[sd]?|ed)\s+to)\s*:?\s*"
+        r"(?:"
+        r"https://github\.com/([\w-]+)/([\w.-]+)/issues/(\d+)"
+        r"|([\w-]+)/([\w.-]+)#(\d+)"
+        r"|#(\d+)"
+        r")"
+    )
+    matches = re.findall(pattern, pr_body, re.IGNORECASE)
+    results = []
+    default_owner, default_repo = default_repo_full_name.split("/")
+    for m in matches:
+        if m[0] and m[1] and m[2]:  # URL
+            results.append((m[0], m[1], int(m[2])))
+        elif m[3] and m[4] and m[5]:  # owner/repo#num
+            results.append((m[3], m[4], int(m[5])))
+        elif m[6]:  # #num
+            results.append((default_owner, default_repo, int(m[6])))
+    # Remove duplicates while preserving order
+    unique_results = []
+    for r in results:
+        if r not in unique_results:
+            unique_results.append(r)
+    return unique_results

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,18 @@
 ## Checklist
 
-- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
+<!-- Pull requests not following the rules will be closed without further inspection. -->
+<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->
+
+- [ ] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
 - [ ] I have manually tested the changes proposed in this pull request.
 - [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
 - [ ] I have updated the documentation.
 
 ## Reference to Existing Issue
 
-Closes #<issue-number>.
+<!-- Please [open a new issue](https://github.com/openwisp/openwisp-utils/issues/new/choose) if there isn't an existing issue yet. -->
 
-Please [open a new issue](https://github.com/openwisp/openwisp-utils/issues/new/choose) if there isn't an existing issue yet.
+Closes #<issue-number>.
 
 ## Description of Changes
 

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -2,12 +2,12 @@ name: PR Issue Auto-Assignment
 
 on:
   pull_request_target:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, closed, edited, ready_for_review]
 
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
@@ -44,6 +44,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BOT_USERNAME: openwisp-companion
+          EXCLUDE_PR_AUTHORS: dependabot[bot]
         run: >
           python .github/actions/bot-autoassign/__main__.py
           issue_assignment "$GITHUB_EVENT_PATH"

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -18,59 +18,9 @@ jobs:
     if: >
       github.repository == 'openwisp/openwisp-utils' &&
       (github.event.action != 'closed' || github.event.pull_request.merged == false)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate Write Token
-        id: generate-write-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Generate Validation Token
-        id: generate-validation-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: >-
-            OpenWISP-Website,django-rest-framework-gis,netengine,django-swappable-models,
-            packet-legacy,netdiff,openVPNServer,netjsonconfig,netjsongraph.js,
-            django-owm-legacy,openwisp-config,ansible-openwisp2,ansible-openwisp2-iptables,
-            luci-openwisp,django-x509,ansible-freeitaliawifi-login-page,
-            ansible-openwisp2-imagegenerator,openwisp-controller,openwisp-users,
-            openwisp-docs,openwrt-zabbixd,openwisp-network-topology,openwisp-utils,
-            django-loci,django-jsonschema-widget,coova-chilli-openwrt,openwisp-radius,
-            openwisp-ipam,lxdock-openwisp2,docker-openwisp,openwisp-wifi-login-pages,
-            openwisp-firmware-upgrader,openwisp-monitoring,openwrt-openwisp-monitoring,
-            openwisp-notifications,openwisp-dev-env,django-flat-json-widget,
-            ansible-ow-influxdb,ansible-wireguard-openwisp,ansible-openwisp-wifi-login-pages,
-            openwisp-vxlan-updater,openwisp-sentry-utils,Stouts.postfix,openwisp-sphinx-theme,
-            .github,django-readonly-issue-demo-30577,django-minify-compress-staticfiles,
-            bot-testing-ground
-
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e .[github_actions]
-
-      - name: Run issue assignment bot
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-write-token.outputs.token }}
-          GITHUB_VALIDATION_TOKEN: ${{ steps.generate-validation-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          BOT_USERNAME: openwisp-companion
-          EXCLUDE_PR_AUTHORS: dependabot[bot]
-        run: >
-          python .github/actions/bot-autoassign/__main__.py
-          issue_assignment "$GITHUB_EVENT_PATH"
+    uses: ./.github/workflows/reusable-bot-autoassign.yml
+    with:
+      bot_command: issue_assignment
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bot-autoassign-stale-pr.yml
+++ b/.github/workflows/bot-autoassign-stale-pr.yml
@@ -17,57 +17,9 @@ concurrency:
 jobs:
   manage-stale-prs-python:
     if: github.repository == 'openwisp/openwisp-utils'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate Write Token
-        id: generate-write-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Generate Validation Token
-        id: generate-validation-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: >-
-            OpenWISP-Website,django-rest-framework-gis,netengine,django-swappable-models,
-            packet-legacy,netdiff,openVPNServer,netjsonconfig,netjsongraph.js,
-            django-owm-legacy,openwisp-config,ansible-openwisp2,ansible-openwisp2-iptables,
-            luci-openwisp,django-x509,ansible-freeitaliawifi-login-page,
-            ansible-openwisp2-imagegenerator,openwisp-controller,openwisp-users,
-            openwisp-docs,openwrt-zabbixd,openwisp-network-topology,openwisp-utils,
-            django-loci,django-jsonschema-widget,coova-chilli-openwrt,openwisp-radius,
-            openwisp-ipam,lxdock-openwisp2,docker-openwisp,openwisp-wifi-login-pages,
-            openwisp-firmware-upgrader,openwisp-monitoring,openwrt-openwisp-monitoring,
-            openwisp-notifications,openwisp-dev-env,django-flat-json-widget,
-            ansible-ow-influxdb,ansible-wireguard-openwisp,ansible-openwisp-wifi-login-pages,
-            openwisp-vxlan-updater,openwisp-sentry-utils,Stouts.postfix,openwisp-sphinx-theme,
-            .github,django-readonly-issue-demo-30577,django-minify-compress-staticfiles,
-            bot-testing-ground
-
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e .[github_actions]
-
-      - name: Run stale PR bot
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-write-token.outputs.token }}
-          GITHUB_VALIDATION_TOKEN: ${{ steps.generate-validation-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: >
-          python .github/actions/bot-autoassign/__main__.py
-          stale_pr
+    uses: ./.github/workflows/reusable-bot-autoassign.yml
+    with:
+      bot_command: stale_pr
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/reusable-bot-autoassign.yml
+++ b/.github/workflows/reusable-bot-autoassign.yml
@@ -12,6 +12,21 @@ on:
         type: string
         default: "openwisp-companion"
         description: "The GitHub App username used to detect bot mentions and bot-authored comments"
+      openwisp_utils_repo:
+        required: false
+        type: string
+        default: "openwisp/openwisp-utils"
+        description: "The repository to check out"
+      openwisp_utils_ref:
+        required: false
+        type: string
+        default: "master"
+        description: "The ref to check out"
+      exclude_pr_authors:
+        required: false
+        type: string
+        default: "dependabot[bot]"
+        description: "Comma-separated GitHub usernames exempt from external PR validation"
     secrets:
       OPENWISP_BOT_APP_ID:
         required: true
@@ -28,12 +43,13 @@ jobs:
         with:
           app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
           private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout openwisp-utils
         uses: actions/checkout@v7
         with:
-          repository: openwisp/openwisp-utils
-          ref: master
+          repository: ${{ inputs.openwisp_utils_repo }}
+          ref: ${{ inputs.openwisp_utils_ref }}
           path: openwisp-utils
 
       - name: Set up Python
@@ -51,6 +67,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BOT_COMMAND: ${{ inputs.bot_command }}
           BOT_USERNAME: ${{ inputs.bot_username }}
+          EXCLUDE_PR_AUTHORS: ${{ inputs.exclude_pr_authors }}
         run: |
           if [ -n "$GITHUB_EVENT_PATH" ]; then
             python openwisp-utils/.github/actions/bot-autoassign/__main__.py "$BOT_COMMAND" "$GITHUB_EVENT_PATH"

--- a/.github/workflows/reusable-bot-autoassign.yml
+++ b/.github/workflows/reusable-bot-autoassign.yml
@@ -39,38 +39,29 @@ env:
     openwisp/django-rest-framework-gis
     openwisp/netengine
     openwisp/django-swappable-models
-    openwisp/packet-legacy
     openwisp/netdiff
-    openwisp/openVPNServer
     openwisp/netjsonconfig
     openwisp/netjsongraph.js
     openwisp/django-owm-legacy
     openwisp/openwisp-config
     openwisp/ansible-openwisp2
     openwisp/ansible-openwisp2-iptables
-    openwisp/luci-openwisp
     openwisp/django-x509
-    openwisp/ansible-freeitaliawifi-login-page
     openwisp/ansible-openwisp2-imagegenerator
     openwisp/openwisp-controller
     openwisp/openwisp-users
     openwisp/openwisp-docs
-    openwisp/openwrt-zabbixd
     openwisp/openwisp-network-topology
     openwisp/openwisp-utils
     openwisp/django-loci
-    openwisp/django-jsonschema-widget
-    openwisp/coova-chilli-openwrt
     openwisp/openwisp-radius
     openwisp/openwisp-ipam
-    openwisp/lxdock-openwisp2
     openwisp/docker-openwisp
     openwisp/openwisp-wifi-login-pages
     openwisp/openwisp-firmware-upgrader
     openwisp/openwisp-monitoring
     openwisp/openwrt-openwisp-monitoring
     openwisp/openwisp-notifications
-    openwisp/openwisp-dev-env
     openwisp/django-flat-json-widget
     openwisp/ansible-ow-influxdb
     openwisp/ansible-wireguard-openwisp
@@ -78,9 +69,6 @@ env:
     openwisp/openwisp-vxlan-updater
     openwisp/openwisp-sentry-utils
     openwisp/Stouts.postfix
-    openwisp/openwisp-sphinx-theme
-    openwisp/.github
-    openwisp/django-readonly-issue-demo-30577
     openwisp/django-minify-compress-staticfiles
     openwisp/bot-testing-ground
 

--- a/.github/workflows/reusable-bot-autoassign.yml
+++ b/.github/workflows/reusable-bot-autoassign.yml
@@ -33,41 +33,91 @@ on:
       OPENWISP_BOT_PRIVATE_KEY:
         required: true
 
+env:
+  PUBLIC_VALIDATION_REPOSITORIES: |
+    openwisp/OpenWISP-Website
+    openwisp/django-rest-framework-gis
+    openwisp/netengine
+    openwisp/django-swappable-models
+    openwisp/packet-legacy
+    openwisp/netdiff
+    openwisp/openVPNServer
+    openwisp/netjsonconfig
+    openwisp/netjsongraph.js
+    openwisp/django-owm-legacy
+    openwisp/openwisp-config
+    openwisp/ansible-openwisp2
+    openwisp/ansible-openwisp2-iptables
+    openwisp/luci-openwisp
+    openwisp/django-x509
+    openwisp/ansible-freeitaliawifi-login-page
+    openwisp/ansible-openwisp2-imagegenerator
+    openwisp/openwisp-controller
+    openwisp/openwisp-users
+    openwisp/openwisp-docs
+    openwisp/openwrt-zabbixd
+    openwisp/openwisp-network-topology
+    openwisp/openwisp-utils
+    openwisp/django-loci
+    openwisp/django-jsonschema-widget
+    openwisp/coova-chilli-openwrt
+    openwisp/openwisp-radius
+    openwisp/openwisp-ipam
+    openwisp/lxdock-openwisp2
+    openwisp/docker-openwisp
+    openwisp/openwisp-wifi-login-pages
+    openwisp/openwisp-firmware-upgrader
+    openwisp/openwisp-monitoring
+    openwisp/openwrt-openwisp-monitoring
+    openwisp/openwisp-notifications
+    openwisp/openwisp-dev-env
+    openwisp/django-flat-json-widget
+    openwisp/ansible-ow-influxdb
+    openwisp/ansible-wireguard-openwisp
+    openwisp/ansible-openwisp-wifi-login-pages
+    openwisp/openwisp-vxlan-updater
+    openwisp/openwisp-sentry-utils
+    openwisp/Stouts.postfix
+    openwisp/openwisp-sphinx-theme
+    openwisp/.github
+    openwisp/django-readonly-issue-demo-30577
+    openwisp/django-minify-compress-staticfiles
+    openwisp/bot-testing-ground
+
 jobs:
   run-bot:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate Write Token
-        id: generate-write-token
+      - name: Generate repository write token
+        id: write-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
           private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-issues: write
+          permission-pull-requests: write
 
-      - name: Generate Validation Token
-        id: generate-validation-token
+      - name: Check validation repository list
+        run: |
+          if [ -z "$PUBLIC_VALIDATION_REPOSITORIES" ]; then
+            echo "Error: PUBLIC_VALIDATION_REPOSITORIES environment variable is empty."
+            echo "Failing to prevent minting a token with org-wide access."
+            exit 1
+          fi
+
+      - name: Generate validation token
+        id: validation-token
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
           private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: >-
-            OpenWISP-Website,django-rest-framework-gis,netengine,django-swappable-models,
-            packet-legacy,netdiff,openVPNServer,netjsonconfig,netjsongraph.js,
-            django-owm-legacy,openwisp-config,ansible-openwisp2,ansible-openwisp2-iptables,
-            luci-openwisp,django-x509,ansible-freeitaliawifi-login-page,
-            ansible-openwisp2-imagegenerator,openwisp-controller,openwisp-users,
-            openwisp-docs,openwrt-zabbixd,openwisp-network-topology,openwisp-utils,
-            django-loci,django-jsonschema-widget,coova-chilli-openwrt,openwisp-radius,
-            openwisp-ipam,lxdock-openwisp2,docker-openwisp,openwisp-wifi-login-pages,
-            openwisp-firmware-upgrader,openwisp-monitoring,openwrt-openwisp-monitoring,
-            openwisp-notifications,openwisp-dev-env,django-flat-json-widget,
-            ansible-ow-influxdb,ansible-wireguard-openwisp,ansible-openwisp-wifi-login-pages,
-            openwisp-vxlan-updater,openwisp-sentry-utils,Stouts.postfix,openwisp-sphinx-theme,
-            .github,django-readonly-issue-demo-30577,django-minify-compress-staticfiles,
-            bot-testing-ground
+          repositories: ${{ env.PUBLIC_VALIDATION_REPOSITORIES }}
+          permission-issues: read
+          permission-organization-projects: read
+          permission-repository-projects: read
 
       - name: Checkout openwisp-utils
         uses: actions/checkout@v7
@@ -86,8 +136,8 @@ jobs:
 
       - name: Execute bot script
         env:
-          GITHUB_TOKEN: ${{ steps.generate-write-token.outputs.token }}
-          GITHUB_VALIDATION_TOKEN: ${{ steps.generate-validation-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.write-token.outputs.token }}
+          VALIDATION_GITHUB_TOKEN: ${{ steps.validation-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BOT_COMMAND: ${{ inputs.bot_command }}

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -73,6 +73,56 @@ OpenWISP repositories. The bot provides the following features:
   encouragement after 60 days. The bot does not auto-close PRs.
 - **PR reopen reassignment**: When a stale PR is reopened, linked issues
   are reassigned back to the author.
+- **PR validation**: Flags invalid pull requests from external
+  contributors that do not reference a validated issue belonging to the
+  OpenWISP organization (an open issue assigned to one of the required
+  project boards with at least one label other than ``invalid`` or
+  ``wontfix``). Invalid pull requests are labeled ``invalid``, receive a
+  warning comment, and are automatically closed after 24 hours if the
+  issue is not resolved.
+
+**How External PR Validation Works**
+
+The PR issue-link workflow runs on ``pull_request_target`` events
+(``opened``, ``reopened``, ``closed``, ``edited``, and
+``ready_for_review``). For each pull request:
+
+1. **Maintainer exemption.** Pull requests authored by users with
+   ``OWNER``, ``MEMBER``, or ``COLLABORATOR`` ``author_association``
+   values proceed normally without issue validation. The same applies to
+   authors listed in the ``EXCLUDE_PR_AUTHORS`` environment variable
+   (``dependabot[bot]`` by default).
+2. **Validated issue requirement.** External contributors must reference
+   at least one validated issue in the pull request description using
+   ``Fixes #ISSUE_NUMBER``, ``Closes #ISSUE_NUMBER``, ``Related to
+   #ISSUE_NUMBER``, or an equivalent cross-repository reference. Only the
+   pull request description is checked (not commit messages or the title).
+3. **Validated issue criteria.** A linked issue is considered validated
+   when all of the following are true:
+
+   - it is open;
+   - it belongs to the same GitHub organization as the repository;
+   - it has at least one label other than ``invalid`` or ``wontfix``;
+   - it is assigned to one of these OpenWISP contributor project boards:
+
+     - OpenWISP Contributor's Board
+     - OpenWISP Priorities for next releases
+
+4. **Invalid pull request handling.** When validation fails, the bot adds
+   the standard ``invalid`` label, posts a single explanatory comment
+   (tracked with a hidden HTML marker), and explains how to fix the pull
+   request. Draft and documentation-only pull requests are not exempt.
+5. **Recovery and auto-close.** When a contributor updates the pull
+   request description to reference a validated issue, the next workflow
+   run removes the ``invalid`` label automatically. The daily stale PR job
+   re-checks pull requests labeled ``invalid``: if validation still fails
+   24 hours after the warning comment, the pull request is closed
+   automatically. Maintainers should validate the linked issue (open,
+   labeled, and assigned to a contributor project board) rather than
+   removing the ``invalid`` label manually.
+6. **API failures.** If the bot cannot verify project-board assignment
+   because of a GitHub API or permission error, the workflow fails and is
+   retried on the next run as usual.
 
 **How Stale PR Detection Works**
 
@@ -116,6 +166,13 @@ defaults to ``openwisp-companion``).
 - ``OPENWISP_BOT_APP_ID`` (required): OpenWISP Bot GitHub App ID.
 - ``OPENWISP_BOT_PRIVATE_KEY`` (required): OpenWISP Bot GitHub App private
   key.
+
+The OpenWISP Bot GitHub App must also have **Projects: Read** permission
+(enabled at the organization level). PR validation uses a lightweight
+GraphQL query on each linked issue's ``projectItems`` to read only the
+assigned project title — it does not traverse or modify project boards.
+Without this permission, the API returns no project data and external pull
+requests may be falsely flagged as ``invalid``.
 
 **Setup for Other Repositories**
 
@@ -167,11 +224,11 @@ Create the following workflow files in your repository.
     name: PR Issue Auto-Assignment
     on:
       pull_request_target:
-        types: [opened, reopened, closed]
+        types: [opened, reopened, closed, edited, ready_for_review]
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     concurrency:
       group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
       cancel-in-progress: true

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -73,40 +73,11 @@ OpenWISP repositories. The bot provides the following features:
   encouragement after 60 days. The bot does not auto-close PRs.
 - **PR reopen reassignment**: When a stale PR is reopened, linked issues
   are reassigned back to the author.
-- **PR validation**: Flags invalid pull requests from external
-  contributors that do not reference a validated issue belonging to the
-  OpenWISP organization.
-
-**How External PR Validation Works**
-
-The PR issue-link workflow runs on ``pull_request_target`` events
-(``opened``, ``reopened``, ``closed``, ``edited``, and
-``ready_for_review``). For each pull request:
-
-1. **Maintainer exemption.** Maintainers (``OWNER``, ``MEMBER``, ``COLLABORATOR``)
-       and excluded authors (like ``dependabot[bot]``) bypass issue
-       validation.
-2. **Validated issue requirement.** External contributors must reference
-   at least one validated issue in the pull request description using
-   ``Fixes #ISSUE_NUMBER``, ``Closes #ISSUE_NUMBER``, ``Related to
-   #ISSUE_NUMBER``, or an equivalent cross-repository reference.
-3. **Validated issue criteria.** A linked issue is considered validated
-   when all of the following are true:
-
-   - it is open;
-   - it belongs to the same GitHub organization as the repository;
-   - it has at least one label other than ``invalid`` or ``wontfix``;
-   - it is assigned to one of these OpenWISP contributor project boards:
-
-     - OpenWISP Contributor's Board
-     - OpenWISP Priorities for next releases
-
-4. **Invalid pull request handling.** When validation fails, the bot adds
-   the standard ``invalid`` label, posts a single explanatory comment and
-   explains how to fix the pull request.
-5. **Recovery and auto-close.** When a contributor updates the pull
-   request description to reference a validated issue, the next workflow
-   run removes the ``invalid`` label automatically.
+- **PR validation**: Enforces the `OpenWISP Contributing Guidelines
+  <https://openwisp.io/docs/dev/developer/contributing.html>`_ for
+  external contributors by flagging PRs that do not link a validated
+  issue. The bot removes the ``invalid`` label once the PR is valid and
+  closes unresolved invalid PRs after 24 hours.
 
 **How Stale PR Detection Works**
 
@@ -144,16 +115,16 @@ The Stale PR job runs daily. For each open PR:
 These secrets are used by the workflow to generate a ``GITHUB_TOKEN`` via
 the ``actions/create-github-app-token`` action. The bot itself consumes
 the following environment variables at runtime: ``GITHUB_TOKEN``,
-``REPOSITORY``, ``GITHUB_EVENT_NAME``, and ``BOT_USERNAME`` (optional;
-defaults to ``openwisp-companion``).
+``VALIDATION_GITHUB_TOKEN``, ``REPOSITORY``, ``GITHUB_EVENT_NAME``, and
+``BOT_USERNAME`` (optional; defaults to ``openwisp-companion``).
 
 - ``OPENWISP_BOT_APP_ID`` (required): OpenWISP Bot GitHub App ID.
 - ``OPENWISP_BOT_PRIVATE_KEY`` (required): OpenWISP Bot GitHub App private
   key.
 
 The OpenWISP Bot needs **Projects: Read** permission at the org level to
-check assigned project titles via GraphQL. Without it, valid external PRs
-might be wrongly flagged as ``invalid``.
+check issue project assignments via GraphQL. Without it, valid external
+PRs might be wrongly flagged as ``invalid``.
 
 **Setup for Other Repositories**
 

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -112,11 +112,13 @@ The Stale PR job runs daily. For each open PR:
 
 **Secrets**
 
-These secrets are used by the workflow to generate a ``GITHUB_TOKEN`` via
-the ``actions/create-github-app-token`` action. The bot itself consumes
-the following environment variables at runtime: ``GITHUB_TOKEN``,
-``VALIDATION_GITHUB_TOKEN``, ``REPOSITORY``, ``GITHUB_EVENT_NAME``, and
-``BOT_USERNAME`` (optional; defaults to ``openwisp-companion``).
+These secrets let the reusable workflow mint two GitHub App tokens with
+``actions/create-github-app-token``. A repository-scoped write token is
+passed to the bot as ``GITHUB_TOKEN`` for issue assignment, labels,
+comments, and PR closure. A separate read-only validation token, scoped to
+the approved public repositories, is passed as ``VALIDATION_GITHUB_TOKEN``
+to validate linked issues and project assignments. The caller workflow's
+ambient token is not used for these mutations.
 
 - ``OPENWISP_BOT_APP_ID`` (required): OpenWISP Bot GitHub App ID.
 - ``OPENWISP_BOT_PRIVATE_KEY`` (required): OpenWISP Bot GitHub App private
@@ -180,9 +182,9 @@ Create the following workflow files in your repository.
     permissions:
       contents: read
       issues: write
-      pull-requests: write
+      pull-requests: read
     concurrency:
-      group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
+      group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     jobs:
       auto-assign-issue:

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         ],
         "github_actions": [
             "google-genai>=1.62.0,<3.0.0",
-            "PyGithub>=2.0.0,<3.0.0",
+            "PyGithub>=2.5.0,<3.0.0",
         ],
     },
     classifiers=[


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #709 .

## Description of Changes
## What this does

External contributors must now link their pull request to an issue that maintainers have already validated, before it can be reviewed. This helps filter out unsolicited, low-quality, or AI-generated PRs that don't address a problem maintainers actually want worked on.

> Maintainers, org members, and collaborators are unaffected — they can keep opening PRs as before, with or without a linked issue.

## How it works

1. When an external contributor opens or updates a PR, the bot checks if it references an issue that is:
   - open
   -  labeled with something other than `invalid` or `wontfix`
   -  in the `openwisp` organization (same repo or another org repo)
   -  assigned to one of the approved contributor project boards

2. If no such issue is referenced, the bot:
   -  adds the `invalid` label
   -  posts a comment explaining why, and how to fix it

3. A daily scheduled check re-evaluates flagged PRs:
   -  if the PR now links to a validated issue → `invalid` is removed automatically
   -  if it's still unresolved 24 hours after the warning comment → the PR is closed automatically

## Changes in this PR

- **Workflow triggers** (`bot-autoassign-pr-issue-link.yml`): now also runs on `edited` and `ready_for_review` events, so contributors don't have to wait for the daily job to get re-checked after fixing their PR.
- **Issue reference parsing** (`utils.py`): added `extract_all_linked_issues`, which recognizes same-repo (`#123`), cross-repo (`org/repo#123`), and full issue URL references.
- **Validation logic** (`base.py`): added `validate_pr_issues`, which applies the checks above and exempts owners, members, collaborators, and trusted bots (e.g. Dependabot).
- **Bot behavior**: labels invalid PRs, posts the warning comment, and automatically removes the label once the PR is updated to reference a validated issue.
- **Scheduled cleanup** (`stale_pr_bot.py`): automatically closes PRs still flagged `invalid` 24 hours after the warning comment.
- **Tests**: added coverage in `test_issue_assignment_bot.py` and `test_stale_pr_bot.py` for the positive, negative, and edge cases.
- **Docs**: updated `docs/developer/reusable-github-utils.rst` to describe the new triggers, requirements, and policy.
- **Tokens**:Split the token into read and write for least privilege

## Screenshot

N/A
