### PR TITLE
[change] Excluded local python venv dirs from QA checks #720

### DIFF
--- a/docs/developer/qa-checks.rst
+++ b/docs/developer/qa-checks.rst
@@ -50,7 +50,11 @@ Usage example:
 
     openwisp-qa-check --migration-path <path> --message <commit-message>
 
-Any unneeded checks can be skipped by passing ``--skip-<check-name>``
+Any unneeded checks can be skipped by passing ``--skip-<check-name>``.
+
+Local virtual environments are excluded from all QA and formatting
+commands. The excluded directory names are ``.venv``, ``venv``, ``env``,
+and ``.tox``.
 
 Usage example:
 

--- a/docs/developer/qa-checks.rst
+++ b/docs/developer/qa-checks.rst
@@ -56,6 +56,9 @@ Local virtual environments are excluded from all QA and formatting
 commands. The excluded directory names are ``.venv``, ``venv``, ``env``,
 and ``.tox``.
 
+The blank endline check also excludes coverage artifacts: ``.coverage*``,
+``coverage.xml``, and the ``htmlcov/`` directory.
+
 Usage example:
 
 .. code-block::

--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -50,6 +50,7 @@ echoerr() { echo "$@" 1>&2; }
 
 runcheckendline() {
   flag=0
+  # Read null-delimited paths so filenames containing whitespace stay intact.
   while IFS= read -r -d '' i; do
     if [ "$(tail -c 1 -- "$i")" != "" ]; then
       echo "$i needs newline at the end"
@@ -80,6 +81,7 @@ runprettiercheck() {
     local patterns=(-name "*.yml" -o -name "*.yaml" -o -name "*.md")
     [[ "$1" != "true" ]] && patterns+=(-o -name "*.js" -o -name "*.json")
     [[ "$2" != "true" ]] && patterns+=(-o -name "*.css")
+    # Collect null-delimited paths so formatter arguments preserve whitespace.
     while IFS= read -r -d '' file; do
       files+=("$file")
     done < <(find . -path "*/.venv/*" -prune -o -path "*/venv/*" -prune \

--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -52,6 +52,13 @@ runcheckendline() {
   flag=0
   for i in $(find . -type f ! -path "*/*.egg-info/*" \
     ! -path "./.*" \
+    ! -path "*/.venv/*" \
+    ! -path "*/venv/*" \
+    ! -path "*/env/*" \
+    ! -path "*/.tox/*" \
+    ! -path "*/htmlcov/*" \
+    ! -path "*/.coverage*" \
+    ! -path "*/coverage.xml" \
     ! -path "*.min.*" \
     ! -path "*.svg" -exec grep -Iq . {} \; -and -print); do
     if [ "$(tail -c 1 $i)" != "" ]; then
@@ -69,20 +76,27 @@ runcheckendline() {
 
 runprettiercheck() {
   if which prettier > /dev/null; then
-    JS_PATTERN=""
-    CSS_PATTERN=""
-    [[ "$1" != "true" ]] && JS_PATTERN="|js|json"
-    [[ "$2" != "true" ]] && CSS_PATTERN="|css"
-    PATTERN="**/*.+(yml|yaml|md${JS_PATTERN}${CSS_PATTERN})"
+    local files=()
+    local patterns=(-name "*.yml" -o -name "*.yaml" -o -name "*.md")
+    [[ "$1" != "true" ]] && patterns+=(-o -name "*.js" -o -name "*.json")
+    [[ "$2" != "true" ]] && patterns+=(-o -name "*.css")
+    while IFS= read -r -d '' file; do
+      files+=("$file")
+    done < <(find . -path "*/.venv/*" -prune -o -path "*/venv/*" -prune \
+      -o -path "*/env/*" -prune -o -path "*/.tox/*" -prune -o -type f \
+      \( "${patterns[@]}" \) -print0)
 
-    prettier --check $PATTERN --print-width 88 &&
-      echo "SUCCESS: Prettier check successful!" ||
-      {
-        echoerr "ERROR: Prettier check failed! Hint: did you forget to run openwisp-qa-format?"
-        echoerr "For more information refer to:"
-        echoerr "https://openwisp.io/docs/dev/developer/contributing.html#css-and-javascript-code-conventions"
-        FAILURE=1
-      }
+    # Prettier excludes node_modules by default unless --with-node-modules is used.
+    if [ ${#files[@]} -gt 0 ]; then
+      prettier --check "${files[@]}" --print-width 88 &&
+        echo "SUCCESS: Prettier check successful!" ||
+        {
+          echoerr "ERROR: Prettier check failed! Hint: did you forget to run openwisp-qa-format?"
+          echoerr "For more information refer to:"
+          echoerr "https://openwisp.io/docs/dev/developer/contributing.html#css-and-javascript-code-conventions"
+          FAILURE=1
+        }
+    fi
   else
     echoerr "MODULE NOT FOUND: Please install prettier, e.g.:"
     echoerr "sudo npm install -g prettier"
@@ -110,7 +124,7 @@ runcheckmigrations() {
 }
 
 runflake8() {
-  flake8 && echo "SUCCESS: Flake8 check successful!" ||
+  flake8 --extend-exclude=.venv,venv,env,.tox && echo "SUCCESS: Flake8 check successful!" ||
     {
       echoerr "ERROR: Flake8 check failed!"
       FAILURE=1
@@ -124,6 +138,7 @@ runrstcheck() {
   while IFS= read -r -d '' file; do
     files+=("$file")
   done < <(find . -path "*/.*" -prune -o -path "*/node_modules/*" -prune \
+    -o -path "*/venv/*" -prune -o -path "*/env/*" -prune \
     -o -type f \( -name "*.py" -o -name "*.rst" \) -print0)
   if [ ${#files[@]} -gt 0 ]; then
     local cmd=(docstrfmt --no-docstring-trailing-line -i -c -l 74 -s "=-~+^\"'.:")
@@ -138,7 +153,8 @@ runrstcheck() {
 }
 
 runisort() {
-  isort --check-only --diff --quiet . &&
+  isort --check-only --diff --quiet --extend-skip .venv --extend-skip venv \
+    --extend-skip env --extend-skip .tox . &&
     echo "SUCCESS: Isort check successful!" ||
     {
       echoerr "ERROR: Isort check failed! Hint: did you forget to run openwisp-qa-format?"
@@ -147,7 +163,9 @@ runisort() {
 }
 
 runblack() {
-  black --check --diff --quiet . &&
+  # Black excludes .venv, venv, and .tox by default. Extend its defaults to
+  # cover env and ENV without replacing the built-in exclusions.
+  black --check --diff --quiet --extend-exclude '/(env|ENV)/' . &&
     echo "SUCCESS: Black check successful!" ||
     {
       echoerr "ERROR: Black check failed! Hint: did you forget to run openwisp-qa-format?"

--- a/openwisp-qa-check
+++ b/openwisp-qa-check
@@ -50,7 +50,12 @@ echoerr() { echo "$@" 1>&2; }
 
 runcheckendline() {
   flag=0
-  for i in $(find . -type f ! -path "*/*.egg-info/*" \
+  while IFS= read -r -d '' i; do
+    if [ "$(tail -c 1 -- "$i")" != "" ]; then
+      echo "$i needs newline at the end"
+      flag=1
+    fi
+  done < <(find . -type f ! -path "*/*.egg-info/*" \
     ! -path "./.*" \
     ! -path "*/.venv/*" \
     ! -path "*/venv/*" \
@@ -60,12 +65,7 @@ runcheckendline() {
     ! -path "*/.coverage*" \
     ! -path "*/coverage.xml" \
     ! -path "*.min.*" \
-    ! -path "*.svg" -exec grep -Iq . {} \; -and -print); do
-    if [ "$(tail -c 1 $i)" != "" ]; then
-      echo "$i needs newline at the end"
-      flag=1
-    fi
-  done
+    ! -path "*.svg" -exec grep -Iq . {} \; -and -print0)
   if [ $flag -ne 0 ]; then
     echoerr "ERROR: Blank endline check failed!"
     FAILURE=1

--- a/openwisp-qa-format
+++ b/openwisp-qa-format
@@ -11,9 +11,12 @@ files=()
 while IFS= read -r -d '' file; do
   files+=("$file")
 done < <(find . -path "*/.*" -prune -o -path "*/venv/*" -prune \
-  -o -path "*/env/*" -prune -o -type f \( -name "*.py" -o -name "*.rst" \) -print0)
-docstrfmt --no-docstring-trailing-line --ignore-cache \
-  --section-adornments "=-~+^\"\'.:" --line-length 74 "${files[@]}"
+  -o -path "*/env/*" -prune -o -path "*/node_modules/*" -prune \
+  -o -type f \( -name "*.py" -o -name "*.rst" \) -print0)
+if [ ${#files[@]} -gt 0 ]; then
+  docstrfmt --no-docstring-trailing-line --ignore-cache \
+    --section-adornments "=-~+^\"\'.:" --line-length 74 "${files[@]}"
+fi
 
 if which prettier > /dev/null; then
   files=()

--- a/openwisp-qa-format
+++ b/openwisp-qa-format
@@ -1,14 +1,32 @@
 #!/bin/bash
 set -e
 
-isort .
-black .
+isort --extend-skip .venv --extend-skip venv --extend-skip env \
+  --extend-skip .tox .
+# Black excludes .venv, venv, and .tox by default. Extend its defaults to
+# cover env and ENV without replacing the built-in exclusions.
+black --extend-exclude '/(env|ENV)/' .
+
+files=()
+while IFS= read -r -d '' file; do
+  files+=("$file")
+done < <(find . -path "*/.*" -prune -o -path "*/venv/*" -prune \
+  -o -path "*/env/*" -prune -o -type f \( -name "*.py" -o -name "*.rst" \) -print0)
 docstrfmt --no-docstring-trailing-line --ignore-cache \
-  --section-adornments "=-~+^\"\'.:" \
-  --line-length 74 .
+  --section-adornments "=-~+^\"\'.:" --line-length 74 "${files[@]}"
 
 if which prettier > /dev/null; then
-  prettier --write "**/*.+(yml|yaml|md|js|json|css)" --print-width 88
+  files=()
+  while IFS= read -r -d '' file; do
+    files+=("$file")
+  done < <(find . -path "*/.venv/*" -prune -o -path "*/venv/*" -prune \
+    -o -path "*/env/*" -prune -o -path "*/.tox/*" -prune -o -type f \
+    \( -name "*.yml" -o -name "*.yaml" -o -name "*.md" -o -name "*.js" \
+    -o -name "*.json" -o -name "*.css" \) -print0)
+  # Prettier excludes node_modules by default unless --with-node-modules is used.
+  if [ ${#files[@]} -gt 0 ]; then
+    prettier --write "${files[@]}" --print-width 88
+  fi
 else
   echo "SKIPPED CSS FILES: Please install prettier"
 fi

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -309,22 +309,27 @@ class TestQa(TestCase):
                 capture_output=True,
                 text=True,
             )
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual(
-                result.stdout.count("SUCCESS: ReStructuredText check successful!"),
-                1,
-            )
+            with self.subTest("Check that docstrfmt completes successfully"):
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(
+                    result.stdout.count("SUCCESS: ReStructuredText check successful!"),
+                    1,
+                )
             with open(args_path) as f:
                 args = f.read().splitlines()
             quiet_index = args.index("--quiet")
-            self.assertIn("./work.py", args)
-            self.assertIn("./work with spaces.rst", args)
-            self.assertLess(quiet_index, args.index("./work.py"))
-            self.assertLess(quiet_index, args.index("./work with spaces.rst"))
-            self.assertNotIn("./node_modules/pkg/file.py", args)
-            self.assertNotIn("./node_modules/other/doc.rst", args)
-            self.assertNotIn("./.venv/package/doc.rst", args)
-            self.assertNotIn("./.github/actions/script.py", args)
+            for filename in ("./work.py", "./work with spaces.rst"):
+                with self.subTest(f"Check that docstrfmt formats {filename}"):
+                    self.assertIn(filename, args)
+                    self.assertLess(quiet_index, args.index(filename))
+            for filename in (
+                "./node_modules/pkg/file.py",
+                "./node_modules/other/doc.rst",
+                "./.venv/package/doc.rst",
+                "./.github/actions/script.py",
+            ):
+                with self.subTest(f"Check that docstrfmt ignores {filename}"):
+                    self.assertNotIn(filename, args)
 
     def test_format_excludes_virtual_environments(self):
         script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))
@@ -387,33 +392,41 @@ class TestQa(TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             with open(args_paths["docstrfmt"]) as f:
                 args = f.read().splitlines()
-            self.assertIn("./work.rst", args)
-            for docstrfmt_file in excluded_docstrfmt_files:
-                self.assertNotIn(docstrfmt_file, args)
+            with self.subTest(
+                "Check that docstrfmt excludes virtual-environment files"
+            ):
+                self.assertIn("./work.rst", args)
+                for docstrfmt_file in excluded_docstrfmt_files:
+                    self.assertNotIn(docstrfmt_file, args)
             with open(args_paths["isort"]) as f:
                 isort_args = f.read().splitlines()
-            self.assertEqual(
-                isort_args,
-                [
-                    "--extend-skip",
-                    ".venv",
-                    "--extend-skip",
-                    "venv",
-                    "--extend-skip",
-                    "env",
-                    "--extend-skip",
-                    ".tox",
-                    ".",
-                ],
-            )
+            with self.subTest(
+                "Check that isort receives all virtual-environment exclusions"
+            ):
+                self.assertEqual(
+                    isort_args,
+                    [
+                        "--extend-skip",
+                        ".venv",
+                        "--extend-skip",
+                        "venv",
+                        "--extend-skip",
+                        "env",
+                        "--extend-skip",
+                        ".tox",
+                        ".",
+                    ],
+                )
             with open(args_paths["black"]) as f:
                 black_args = f.read().splitlines()
-            self.assertEqual(black_args, ["--extend-exclude", "/(env|ENV)/", "."])
+            with self.subTest("Check that Black receives its environment exclusion"):
+                self.assertEqual(black_args, ["--extend-exclude", "/(env|ENV)/", "."])
             with open(args_paths["prettier"]) as f:
                 prettier_args = f.read().splitlines()
-            self.assertIn("./work.css", prettier_args)
-            for prettier_file in excluded_prettier_files:
-                self.assertNotIn(prettier_file, prettier_args)
+            with self.subTest("Check that Prettier excludes virtual-environment files"):
+                self.assertIn("./work.css", prettier_args)
+                for prettier_file in excluded_prettier_files:
+                    self.assertNotIn(prettier_file, prettier_args)
 
     def test_format_skips_docstrfmt_without_eligible_files(self):
         script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))
@@ -447,9 +460,11 @@ class TestQa(TestCase):
             result = subprocess.run(
                 [script_path], cwd=temp_dir, env=env, capture_output=True, text=True
             )
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertFalse(path.exists(docstrfmt_called_path))
-            self.assertFalse(path.exists(prettier_called_path))
+            with self.subTest("Check that docstrfmt is skipped without eligible files"):
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertFalse(path.exists(docstrfmt_called_path))
+            with self.subTest("Check that Prettier is skipped without eligible files"):
+                self.assertFalse(path.exists(prettier_called_path))
 
     def test_checkendline_excludes_coverage_artifacts(self):
         script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -282,6 +282,10 @@ class TestQa(TestCase):
             os.makedirs(path.dirname(node_module_rst))
             with open(node_module_rst, "w") as f:
                 f.write("Test\n====\n")
+            venv_rst = path.join(temp_dir, ".venv", "package", "doc.rst")
+            os.makedirs(path.dirname(venv_rst))
+            with open(venv_rst, "w") as f:
+                f.write("Test\n====\n")
             hidden_py = path.join(temp_dir, ".github", "actions", "script.py")
             os.makedirs(path.dirname(hidden_py))
             with open(hidden_py, "w") as f:
@@ -319,4 +323,75 @@ class TestQa(TestCase):
             self.assertLess(quiet_index, args.index("./work with spaces.rst"))
             self.assertNotIn("./node_modules/pkg/file.py", args)
             self.assertNotIn("./node_modules/other/doc.rst", args)
+            self.assertNotIn("./.venv/package/doc.rst", args)
             self.assertNotIn("./.github/actions/script.py", args)
+
+    def test_format_excludes_virtual_environments(self):
+        script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))
+        script_path = path.join(script_path, "openwisp-qa-format")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_dir = path.join(temp_dir, "bin")
+            os.mkdir(bin_dir)
+            args_path = path.join(temp_dir, "docstrfmt-args.txt")
+            for command in ("isort", "black", "prettier"):
+                command_path = path.join(bin_dir, command)
+                with open(command_path, "w") as f:
+                    f.write("#!/bin/sh\n")
+                os.chmod(command_path, 0o755)
+            docstrfmt_path = path.join(bin_dir, "docstrfmt")
+            with open(docstrfmt_path, "w") as f:
+                f.write(
+                    "#!/bin/sh\n"
+                    'for arg in "$@"; do\n'
+                    '    printf "%s\\n" "$arg" >> "$DOCSTRFMT_ARGS"\n'
+                    "done\n"
+                )
+            os.chmod(docstrfmt_path, 0o755)
+            work_file = path.join(temp_dir, "work.rst")
+            with open(work_file, "w") as f:
+                f.write("Test\n====\n")
+            venv_file = path.join(temp_dir, ".venv", "package", "doc.rst")
+            os.makedirs(path.dirname(venv_file))
+            with open(venv_file, "w") as f:
+                f.write("Test\n====\n")
+            env = os.environ.copy()
+            env["DOCSTRFMT_ARGS"] = args_path
+            env["PATH"] = f'{bin_dir}:{env["PATH"]}'
+            result = subprocess.run(
+                [script_path], cwd=temp_dir, env=env, capture_output=True, text=True
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            with open(args_path) as f:
+                args = f.read().splitlines()
+            self.assertIn("./work.rst", args)
+            self.assertNotIn("./.venv/package/doc.rst", args)
+
+    def test_checkendline_excludes_coverage_artifacts(self):
+        script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))
+        script_path = path.join(script_path, "openwisp-qa-check")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            for filename in (
+                ".coverage",
+                "coverage.xml",
+                path.join("htmlcov", "index.html"),
+            ):
+                file_path = path.join(temp_dir, filename)
+                os.makedirs(path.dirname(file_path), exist_ok=True)
+                with open(file_path, "w") as f:
+                    f.write("coverage artifact")
+            result = subprocess.run(
+                [
+                    script_path,
+                    "--skip-checkmigrations",
+                    "--skip-flake8",
+                    "--skip-isort",
+                    "--skip-black",
+                    "--skip-checkrst",
+                    "--skip-checkcommit",
+                    "--skip-checkmakemigrations",
+                ],
+                cwd=temp_dir,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -362,6 +362,7 @@ class TestQa(TestCase):
             with open(prettier_file, "w") as f:
                 f.write("body {}\n")
             excluded_prettier_files = []
+            excluded_docstrfmt_files = []
             for directory in (".venv", "venv", "env", ".tox"):
                 prettier_file = path.join(temp_dir, directory, "package", "file.css")
                 os.makedirs(path.dirname(prettier_file))
@@ -369,6 +370,12 @@ class TestQa(TestCase):
                     f.write("body {}\n")
                 excluded_prettier_files.append(
                     path.join(".", directory, "package", "file.css")
+                )
+                docstrfmt_file = path.join(temp_dir, directory, "package", "doc.rst")
+                with open(docstrfmt_file, "w") as f:
+                    f.write("Test\n====\n")
+                excluded_docstrfmt_files.append(
+                    path.join(".", directory, "package", "doc.rst")
                 )
             env = os.environ.copy()
             for command, args_path in args_paths.items():
@@ -381,7 +388,8 @@ class TestQa(TestCase):
             with open(args_paths["docstrfmt"]) as f:
                 args = f.read().splitlines()
             self.assertIn("./work.rst", args)
-            self.assertNotIn("./.venv/package/doc.rst", args)
+            for docstrfmt_file in excluded_docstrfmt_files:
+                self.assertNotIn(docstrfmt_file, args)
             with open(args_paths["isort"]) as f:
                 isort_args = f.read().splitlines()
             self.assertEqual(
@@ -414,11 +422,16 @@ class TestQa(TestCase):
             bin_dir = path.join(temp_dir, "bin")
             os.mkdir(bin_dir)
             docstrfmt_called_path = path.join(temp_dir, "docstrfmt-called")
-            for command in ("isort", "black", "prettier"):
+            prettier_called_path = path.join(temp_dir, "prettier-called")
+            for command in ("isort", "black"):
                 command_path = path.join(bin_dir, command)
                 with open(command_path, "w") as f:
                     f.write("#!/bin/sh\n")
                 os.chmod(command_path, 0o755)
+            prettier_path = path.join(bin_dir, "prettier")
+            with open(prettier_path, "w") as f:
+                f.write('#!/bin/sh\ntouch "$PRETTIER_CALLED"\n')
+            os.chmod(prettier_path, 0o755)
             docstrfmt_path = path.join(bin_dir, "docstrfmt")
             with open(docstrfmt_path, "w") as f:
                 f.write('#!/bin/sh\ntouch "$DOCSTRFMT_CALLED"\n')
@@ -429,12 +442,14 @@ class TestQa(TestCase):
                 f.write("Test\n====\n")
             env = os.environ.copy()
             env["DOCSTRFMT_CALLED"] = docstrfmt_called_path
+            env["PRETTIER_CALLED"] = prettier_called_path
             env["PATH"] = f'{bin_dir}:{env["PATH"]}'
             result = subprocess.run(
                 [script_path], cwd=temp_dir, env=env, capture_output=True, text=True
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertFalse(path.exists(docstrfmt_called_path))
+            self.assertFalse(path.exists(prettier_called_path))
 
     def test_checkendline_excludes_coverage_artifacts(self):
         script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -361,10 +361,15 @@ class TestQa(TestCase):
             prettier_file = path.join(temp_dir, "work.css")
             with open(prettier_file, "w") as f:
                 f.write("body {}\n")
-            venv_file = path.join(temp_dir, ".venv", "package", "doc.rst")
-            os.makedirs(path.dirname(venv_file))
-            with open(venv_file, "w") as f:
-                f.write("Test\n====\n")
+            excluded_prettier_files = []
+            for directory in (".venv", "venv", "env", ".tox"):
+                prettier_file = path.join(temp_dir, directory, "package", "file.css")
+                os.makedirs(path.dirname(prettier_file))
+                with open(prettier_file, "w") as f:
+                    f.write("body {}\n")
+                excluded_prettier_files.append(
+                    path.join(".", directory, "package", "file.css")
+                )
             env = os.environ.copy()
             for command, args_path in args_paths.items():
                 env[f"{command.upper()}_ARGS"] = args_path
@@ -399,7 +404,8 @@ class TestQa(TestCase):
             with open(args_paths["prettier"]) as f:
                 prettier_args = f.read().splitlines()
             self.assertIn("./work.css", prettier_args)
-            self.assertNotIn("./.venv/package/doc.rst", prettier_args)
+            for prettier_file in excluded_prettier_files:
+                self.assertNotIn(prettier_file, prettier_args)
 
     def test_format_skips_docstrfmt_without_eligible_files(self):
         script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))

--- a/tests/test_project/tests/test_qa.py
+++ b/tests/test_project/tests/test_qa.py
@@ -332,11 +332,19 @@ class TestQa(TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             bin_dir = path.join(temp_dir, "bin")
             os.mkdir(bin_dir)
-            args_path = path.join(temp_dir, "docstrfmt-args.txt")
+            args_paths = {
+                command: path.join(temp_dir, f"{command}-args.txt")
+                for command in ("isort", "black", "prettier", "docstrfmt")
+            }
             for command in ("isort", "black", "prettier"):
                 command_path = path.join(bin_dir, command)
                 with open(command_path, "w") as f:
-                    f.write("#!/bin/sh\n")
+                    f.write(
+                        "#!/bin/sh\n"
+                        'for arg in "$@"; do\n'
+                        f'    printf "%s\\n" "$arg" >> "${{{command.upper()}_ARGS}}"\n'
+                        "done\n"
+                    )
                 os.chmod(command_path, 0o755)
             docstrfmt_path = path.join(bin_dir, "docstrfmt")
             with open(docstrfmt_path, "w") as f:
@@ -350,21 +358,77 @@ class TestQa(TestCase):
             work_file = path.join(temp_dir, "work.rst")
             with open(work_file, "w") as f:
                 f.write("Test\n====\n")
+            prettier_file = path.join(temp_dir, "work.css")
+            with open(prettier_file, "w") as f:
+                f.write("body {}\n")
             venv_file = path.join(temp_dir, ".venv", "package", "doc.rst")
             os.makedirs(path.dirname(venv_file))
             with open(venv_file, "w") as f:
                 f.write("Test\n====\n")
             env = os.environ.copy()
-            env["DOCSTRFMT_ARGS"] = args_path
+            for command, args_path in args_paths.items():
+                env[f"{command.upper()}_ARGS"] = args_path
             env["PATH"] = f'{bin_dir}:{env["PATH"]}'
             result = subprocess.run(
                 [script_path], cwd=temp_dir, env=env, capture_output=True, text=True
             )
             self.assertEqual(result.returncode, 0, result.stderr)
-            with open(args_path) as f:
+            with open(args_paths["docstrfmt"]) as f:
                 args = f.read().splitlines()
             self.assertIn("./work.rst", args)
             self.assertNotIn("./.venv/package/doc.rst", args)
+            with open(args_paths["isort"]) as f:
+                isort_args = f.read().splitlines()
+            self.assertEqual(
+                isort_args,
+                [
+                    "--extend-skip",
+                    ".venv",
+                    "--extend-skip",
+                    "venv",
+                    "--extend-skip",
+                    "env",
+                    "--extend-skip",
+                    ".tox",
+                    ".",
+                ],
+            )
+            with open(args_paths["black"]) as f:
+                black_args = f.read().splitlines()
+            self.assertEqual(black_args, ["--extend-exclude", "/(env|ENV)/", "."])
+            with open(args_paths["prettier"]) as f:
+                prettier_args = f.read().splitlines()
+            self.assertIn("./work.css", prettier_args)
+            self.assertNotIn("./.venv/package/doc.rst", prettier_args)
+
+    def test_format_skips_docstrfmt_without_eligible_files(self):
+        script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))
+        script_path = path.join(script_path, "openwisp-qa-format")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_dir = path.join(temp_dir, "bin")
+            os.mkdir(bin_dir)
+            docstrfmt_called_path = path.join(temp_dir, "docstrfmt-called")
+            for command in ("isort", "black", "prettier"):
+                command_path = path.join(bin_dir, command)
+                with open(command_path, "w") as f:
+                    f.write("#!/bin/sh\n")
+                os.chmod(command_path, 0o755)
+            docstrfmt_path = path.join(bin_dir, "docstrfmt")
+            with open(docstrfmt_path, "w") as f:
+                f.write('#!/bin/sh\ntouch "$DOCSTRFMT_CALLED"\n')
+            os.chmod(docstrfmt_path, 0o755)
+            venv_file = path.join(temp_dir, ".venv", "package", "doc.rst")
+            os.makedirs(path.dirname(venv_file))
+            with open(venv_file, "w") as f:
+                f.write("Test\n====\n")
+            env = os.environ.copy()
+            env["DOCSTRFMT_CALLED"] = docstrfmt_called_path
+            env["PATH"] = f'{bin_dir}:{env["PATH"]}'
+            result = subprocess.run(
+                [script_path], cwd=temp_dir, env=env, capture_output=True, text=True
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(path.exists(docstrfmt_called_path))
 
     def test_checkendline_excludes_coverage_artifacts(self):
         script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))
@@ -395,3 +459,30 @@ class TestQa(TestCase):
                 text=True,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_checkendline_handles_filenames_with_spaces(self):
+        script_path = path.abspath(path.join(path.dirname(__file__), "../../.."))
+        script_path = path.join(script_path, "openwisp-qa-check")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_path = path.join(temp_dir, "file with spaces.py")
+            with open(file_path, "w") as f:
+                f.write("x = 1")
+            result = subprocess.run(
+                [
+                    script_path,
+                    "--skip-checkmigrations",
+                    "--skip-flake8",
+                    "--skip-isort",
+                    "--skip-black",
+                    "--skip-checkrst",
+                    "--skip-checkcommit",
+                    "--skip-checkmakemigrations",
+                ],
+                cwd=temp_dir,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(
+                "./file with spaces.py needs newline at the end", result.stdout
+            )


### PR DESCRIPTION
## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #720

## Description of Changes

Dirs like `.venv/`, `venv/`, `env/`, and `.tox/`
are always excluded from QA check and QA format.
