### PR TITLE
[fix] Prevented capture decorators from polluting exceptions

### DIFF
--- a/openwisp_utils/tests/utils.py
+++ b/openwisp_utils/tests/utils.py
@@ -1,6 +1,7 @@
 import io
 import sys
 from contextlib import contextmanager
+from inspect import signature
 from time import time
 from unittest import TextTestResult, mock
 
@@ -81,22 +82,34 @@ class TimeLoggingTestRunner(DiscoverRunner):
 
 
 class CaptureOutput(object):
+    """Capture test output and optionally pass the streams to the test."""
+
     def __call__(self, function):
         def wrapped_function(*args, **kwargs):
             if hasattr(self, "stdout"):
                 sys.stdout = self.stdout
             if hasattr(self, "stderr"):
                 sys.stderr = self.stderr
-            original_args = list(args)
-            args = list(args)
+            capture_args = []
+            if hasattr(self, "stdout"):
+                capture_args.append(self.stdout)
+            if hasattr(self, "stderr"):
+                capture_args.append(self.stderr)
+            # mock.patch appends positional mocks when its wrapper runs. Include
+            # placeholders so the signature check reflects the eventual call.
+            patch_args = [
+                None
+                for patching in getattr(function, "patchings", [])
+                if patching.attribute_name is None and patching.new is mock.DEFAULT
+            ]
+            # Check the call shape without executing the test. Captured streams
+            # are omitted when the decorated function does not accept them.
             try:
-                if hasattr(self, "stdout"):
-                    args.append(self.stdout)
-                if hasattr(self, "stderr"):
-                    args.append(self.stderr)
-                function(*args, **kwargs)
+                signature(function).bind(*args, *capture_args, *patch_args, **kwargs)
             except TypeError:
-                function(*original_args, **kwargs)
+                capture_args = []
+            try:
+                function(*args, *capture_args, **kwargs)
             finally:
                 if hasattr(self, "stdout"):
                     self.stdout.close()

--- a/tests/test_project/tests/test_test_utils.py
+++ b/tests/test_project/tests/test_test_utils.py
@@ -1,3 +1,4 @@
+import io
 import sys
 from unittest.mock import patch
 
@@ -88,6 +89,65 @@ class TestUtils(TestCase):
     def test_capture_stderr(self, captured_error):
         print("Testing capture_stderr", file=sys.stderr, end="")
         self.assertEqual(captured_error.getvalue(), "Testing capture_stderr")
+
+    def test_capture_output_does_not_pollute_exception_context(self):
+        @capture_any_output()
+        def raise_regression():
+            raise RuntimeError("real regression")
+
+        with self.assertRaisesRegex(RuntimeError, "real regression") as error:
+            raise_regression()
+        self.assertIsNone(
+            error.exception.__context__,
+            "The capture decorator must not pollute the real exception context.",
+        )
+
+    def test_capture_output_argument_injection(self):
+        with self.subTest("stacked patch without capture argument"):
+            received = []
+
+            @capture_stderr()
+            @patch("urllib3.util.retry.Retry.sleep")
+            def decorated(mocked_sleep):
+                received.append(mocked_sleep)
+
+            decorated()
+            received[0].assert_not_called()
+
+        with self.subTest("stacked patch with capture argument"):
+            received = []
+
+            @capture_stderr()
+            @patch("urllib3.util.retry.Retry.sleep")
+            def decorated(captured_error, mocked_sleep):
+                received.extend([captured_error, mocked_sleep])
+
+            decorated()
+            self.assertIsInstance(received[0], io.StringIO)
+            received[1].assert_not_called()
+
+        with self.subTest("variadic arguments"):
+            received = []
+
+            @capture_any_output()
+            def decorated(*streams):
+                received.extend(streams)
+
+            decorated()
+            self.assertEqual(len(received), 2)
+            self.assertTrue(all(isinstance(stream, io.StringIO) for stream in received))
+
+    def test_capture_output_does_not_retry_type_error(self):
+        calls = []
+
+        @capture_stdout()
+        def raise_type_error(captured_output):
+            calls.append(captured_output)
+            raise TypeError("real regression")
+
+        with self.assertRaisesRegex(TypeError, "real regression"):
+            raise_type_error()
+        self.assertEqual(len(calls), 1)
 
     @patch("urllib3.util.retry.Retry.sleep")
     def test_retryable_request(self, *args):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

The output-capture decorators previously attempted to inject captured streams and retried after any TypeError. When a no-argument decorated test then failed for a real reason, the expected signature mismatch was retained as exception context and obscured the regression traceback.

The decorators now determine the valid call shape before executing the test. Existing no-argument, explicit-stream, variadic, and stacked mock.patch forms remain covered.

## Screenshot

Not applicable.