### PR TITLE
[ci:fix] Exempted Companion bot from PR validation

### DIFF
--- a/.github/actions/bot-autoassign/base.py
+++ b/.github/actions/bot-autoassign/base.py
@@ -142,6 +142,9 @@ class GitHubBot:
             if pr.user and isinstance(getattr(pr.user, "login", None), str)
             else ""
         )
+        if pr_author == self.bot_login:
+            print(f"Author {pr_author} is the configured bot. Proceeding.")
+            return True
         exclude_authors_env = os.environ.get(
             "EXCLUDE_PR_AUTHORS", DEFAULT_EXCLUDE_PR_AUTHORS
         )

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -1101,6 +1101,15 @@ class TestPRValidation:
         mock_pr.author_association = "MEMBER"
         assert bot.validate_pr_issues(mock_pr)
 
+    def test_validate_pr_issues_exempt_bot_author(self, bot_env):
+        bot = IssueAssignmentBot()
+        mock_pr = Mock()
+        mock_pr.user.login = "openwisp-companion[bot]"
+        mock_pr.author_association = "NONE"
+        mock_pr.body = "Backport of #504 to `1.2`."
+        assert bot.validate_pr_issues(mock_pr)
+        bot_env["repo_validation"].get_issue.assert_not_called()
+
     def test_validate_pr_issues_no_issues(self, bot_env):
         bot = IssueAssignmentBot()
         mock_pr = Mock()

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -1108,6 +1108,8 @@ class TestPRValidation:
         mock_pr.author_association = "NONE"
         mock_pr.body = "Backport of #504 to `1.2`."
         assert bot.validate_pr_issues(mock_pr)
+        bot_env["github_validation"].get_repo.assert_not_called()
+        bot.github_validation.requester.graphql_query.assert_not_called()
         bot_env["repo_validation"].get_issue.assert_not_called()
 
     def test_validate_pr_issues_no_issues(self, bot_env):

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -70,7 +70,7 @@ OpenWISP repositories. The bot provides the following features:
   no assignment is needed — just open a PR.
 - **Stale PR management**: Warns PR authors after 7 days of inactivity,
   marks stale and unassigns after 14 days, and posts a final follow-up
-  encouragement after 60 days. The bot does not auto-close PRs.
+  encouragement after 60 days. The bot does not auto-close stale PRs.
 - **PR reopen reassignment**: When a stale PR is reopened, linked issues
   are reassigned back to the author.
 - **PR validation**: Enforces the `OpenWISP Contributing Guidelines

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -76,8 +76,9 @@ OpenWISP repositories. The bot provides the following features:
 - **PR validation**: Enforces the `OpenWISP Contributing Guidelines
   <https://openwisp.io/docs/dev/developer/contributing.html>`_ for
   external contributors by flagging PRs that do not link a validated
-  issue. The bot removes the ``invalid`` label once the PR is valid and
-  closes unresolved invalid PRs after 24 hours.
+  issue. PRs created by the configured GitHub App are exempt. The bot
+  removes the ``invalid`` label once the PR is valid and closes unresolved
+  invalid PRs after 24 hours.
 
 **How Stale PR Detection Works**
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A. Related to [openwisp/openwisp-notifications#505](https://github.com/openwisp/openwisp-notifications/pull/505).

## Description of Changes

Exempts pull requests created by the configured GitHub App from external-contributor validation. This prevents OpenWISP Companion backports, whose `author_association` is `NONE`, from being marked `invalid`. Adds regression coverage for that case.

## Screenshot

N/A