### PR TITLE
[ci] CI failure analysis: --allow-escape-sequences

### DIFF
--- a/.github/actions/bot-ci-failure/test_analyze_failure.py
+++ b/.github/actions/bot-ci-failure/test_analyze_failure.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -19,6 +20,19 @@ from analyze_failure import (  # noqa: E402
     main,
     process_error_logs,
 )
+
+
+class TestReusableWorkflow(unittest.TestCase):
+    def test_allows_escape_sequences_when_fetching_job_logs(self):
+        workflow = (
+            Path(__file__).resolve().parents[3]
+            / ".github/workflows/reusable-bot-ci-failure.yml"
+        )
+        fetch_command = (
+            "gh api --allow-escape-sequences "
+            "repos/$REPO/actions/jobs/$JOB_ID/logs > job_logs.txt"
+        )
+        self.assertIn(fetch_command, workflow.read_text())
 
 
 class TestGetErrorLogs(unittest.TestCase):

--- a/.github/workflows/reusable-bot-ci-failure.yml
+++ b/.github/workflows/reusable-bot-ci-failure.yml
@@ -95,7 +95,7 @@ jobs:
           > failed_logs.txt
           for JOB_ID in $JOB_IDS; do
             echo "Processing job $JOB_ID"
-            if ! gh api repos/$REPO/actions/jobs/$JOB_ID/logs > job_logs.txt; then
+            if ! gh api --allow-escape-sequences repos/$REPO/actions/jobs/$JOB_ID/logs > job_logs.txt; then
               echo "Could not fetch logs for job $JOB_ID; skipping." >> failed_logs.txt
               continue
             fi


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Allows the GitHub CLI job-log fetch to output terminal escape sequences, preserving GitHub Actions error markers for the existing failure extractor. Adds regression coverage for the required CLI option.

## Screenshot

N/A