### PR TITLE
[tests] Added new selenium test helpers (wait_until, etc)

### DIFF
--- a/docs/developer/test-utilities.rst
+++ b/docs/developer/test-utilities.rst
@@ -347,3 +347,37 @@ Selenium's ``WebDriverWait`` and Expected Conditions (``EC``).
 
 If the timeout is reached, the test fails with a descriptive error
 message.
+
+``wait_until(condition, timeout=2, driver=None)``
++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Waits until a custom Selenium expected condition or callable returns a
+truthy value. Returns that value and preserves Selenium's
+``TimeoutException``, allowing tests to provide a domain-specific failure
+message when needed.
+
+All standard Selenium waits default to two seconds, so tests must omit the
+``timeout`` argument in the normal case. Use ``timeout=5`` only for a
+concrete external asynchronous boundary, such as WebSocket delivery,
+geocoding, chart rendering, or a page navigation.
+
+``wait_for_script(script, *args, timeout=2, driver=None)``
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Executes ``script`` until it returns a truthy value. Positional arguments
+are passed to Selenium as JavaScript arguments and the final script result
+is returned. This method uses ``wait_until()`` internally and is useful
+for waiting for JavaScript-managed UI state.
+
+``assert_no_browser_errors(driver=None)``
++++++++++++++++++++++++++++++++++++++++++
+
+Asserts that the current page has no relevant ``SEVERE`` browser console
+entries. It uses ``get_browser_errors()`` and therefore applies the
+mixin's configured ignored-message filtering.
+
+``wait_for_admin_success_message(timeout=2, driver=None)``
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+Waits for Django admin's ``.messagelist .success`` confirmation message
+and returns the matching element.

--- a/openwisp_utils/tests/selenium.py
+++ b/openwisp_utils/tests/selenium.py
@@ -411,6 +411,17 @@ class SeleniumTestMixin:
         driver = driver or self.web_driver
         return self.wait_for("presence_of_element_located", by, value, timeout, driver)
 
+    def wait_until(self, condition, timeout=2, driver=None):
+        driver = driver or self.web_driver
+        return WebDriverWait(driver, timeout).until(condition)
+
+    def wait_for_script(self, script, *args, timeout=2, driver=None):
+        return self.wait_until(
+            lambda current_driver: current_driver.execute_script(script, *args),
+            timeout=timeout,
+            driver=driver,
+        )
+
     def wait_for(self, method, by, value, timeout=2, driver=None):
         driver = driver or self.web_driver
         try:
@@ -420,6 +431,14 @@ class SeleniumTestMixin:
         except TimeoutException as e:
             print(self.get_browser_logs(driver))
             self.fail(f'{method} of "{value}" failed: {e}')
+
+    def assert_no_browser_errors(self, driver=None):
+        self.assertEqual(self.get_browser_errors(driver=driver), [])
+
+    def wait_for_admin_success_message(self, timeout=2, driver=None):
+        return self.wait_for_presence(
+            By.CSS_SELECTOR, ".messagelist .success", timeout, driver
+        )
 
     def hide_loading_overlay(self, html_id="loading-overlay", timeout=2, driver=None):
         """The geckodriver can't figure out the loading overlay is still fading out, so let's just hide it."""

--- a/tests/test_project/tests/test_selenium.py
+++ b/tests/test_project/tests/test_selenium.py
@@ -622,7 +622,6 @@ class TestDashboardCharts(SeleniumTestMixin, CreateMixin, ChannelsLiveServerTest
         annotation_text = self.wait_for_visibility(
             By.CSS_SELECTOR,
             ".operator-project-distribution .annotation-text tspan",
-            timeout=10,
         )
         self.assertEqual(annotation_text.text, "0")
 

--- a/tests/test_project/tests/test_selenium_mixin.py
+++ b/tests/test_project/tests/test_selenium_mixin.py
@@ -2,12 +2,15 @@ import importlib
 import sys
 from types import ModuleType
 from unittest import TestResult, TestSuite, skip
+from unittest.mock import Mock
 
 from django.conf import settings
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.test import SimpleTestCase
 from django.test.runner import RemoteTestRunner
 from openwisp_utils.tests.selenium import SeleniumTestMixin
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
 
 
 class SeleniumRetryTestMixin(SeleniumTestMixin, SimpleTestCase):
@@ -140,6 +143,71 @@ class TestSeleniumMixinRetryHandling(SimpleTestCase):
         test._setup_and_call(result)
         self.assertFalse(result.wasSuccessful())
         self.assertEqual(test.calls, 6)
+
+
+class TestSeleniumMixinWaitHelpers(SimpleTestCase):
+    def test_wait_until_uses_default_and_explicit_driver(self):
+        default_driver = object()
+        explicit_driver = object()
+        helper = type("Helper", (), {"web_driver": default_driver})()
+        self.assertIs(
+            SeleniumTestMixin.wait_until(helper, lambda driver: driver, timeout=0),
+            default_driver,
+        )
+        self.assertIs(
+            SeleniumTestMixin.wait_until(
+                helper, lambda driver: driver, timeout=0, driver=explicit_driver
+            ),
+            explicit_driver,
+        )
+
+    def test_wait_until_propagates_timeout_exception(self):
+        helper = type("Helper", (), {"web_driver": object()})()
+        with self.assertRaises(TimeoutException):
+            SeleniumTestMixin.wait_until(helper, lambda driver: False, timeout=0)
+
+    def test_wait_for_script_uses_wait_until_and_passes_script_arguments(self):
+        driver = Mock()
+        helper = Mock()
+        helper.wait_until.side_effect = lambda condition, **kwargs: condition(
+            kwargs["driver"]
+        )
+        driver.execute_script.return_value = {"result": "ready"}
+        result = SeleniumTestMixin.wait_for_script(
+            helper,
+            "return arguments[0];",
+            "ready",
+            timeout=1,
+            driver=driver,
+        )
+        self.assertEqual(result, {"result": "ready"})
+        helper.wait_until.assert_called_once()
+        self.assertEqual(
+            helper.wait_until.call_args.kwargs, {"timeout": 1, "driver": driver}
+        )
+        driver.execute_script.assert_called_once_with("return arguments[0];", "ready")
+
+    def test_assert_no_browser_errors(self):
+        helper = type("Helper", (), {})()
+        driver = object()
+        helper.get_browser_errors = Mock(return_value=[])
+        helper.assertEqual = Mock()
+        SeleniumTestMixin.assert_no_browser_errors(helper, driver=driver)
+        helper.get_browser_errors.assert_called_once_with(driver=driver)
+        helper.assertEqual.assert_called_once_with([], [])
+
+    def test_wait_for_admin_success_message(self):
+        helper = Mock()
+        driver = object()
+        success_message = object()
+        helper.wait_for_presence.return_value = success_message
+        result = SeleniumTestMixin.wait_for_admin_success_message(
+            helper, timeout=1, driver=driver
+        )
+        self.assertIs(result, success_message)
+        helper.wait_for_presence.assert_called_once_with(
+            By.CSS_SELECTOR, ".messagelist .success", 1, driver
+        )
 
 
 class TestSerializeDbConnectionLifecycle(SimpleTestCase):


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A. This small test-utility enhancement does not require a related issue.

## Description of Changes

Added shared Selenium helpers for recurring conditions like JavaScript polling, browser-error assertions and Django admin success messages.

## Screenshot

N/A. This change affects test utilities only.