### PR TITLE
[ci] Opted valid PRs into CodeRabbit reviews #745

### DIFF
--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -456,6 +456,10 @@ class IssueAssignmentBot(GitHubBot):
                     if "invalid" in labels_lower:
                         pr_obj.remove_from_labels("invalid")
                         print(f"Removed 'invalid' label from PR #{pr_number}")
+                    if "ai-review" not in labels_lower:
+                        pr_obj.add_to_labels("ai-review")
+                        pr_obj.create_issue_comment("@coderabbitai review")
+                        print(f"Requested CodeRabbit review for PR #{pr_number}")
                 else:
                     if "invalid" not in labels_lower:
                         pr_obj.add_to_labels("invalid")

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 # Add the parent directory to path for importing bot modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -957,6 +957,13 @@ class TestExtractAllLinkedIssues:
 
 
 class TestPRValidation:
+    def assert_review(self, pr):
+        pr.add_to_labels.assert_called_once_with("ai-review")
+        pr.create_issue_comment.assert_called_once_with("@coderabbitai review")
+        assert pr.method_calls.index(
+            call.add_to_labels("ai-review")
+        ) < pr.method_calls.index(call.create_issue_comment("@coderabbitai review"))
+
     def test_get_issue_projects_success(self, bot_env):
         bot = IssueAssignmentBot()
         bot.github_validation.requester.graphql_query.return_value = (
@@ -1316,6 +1323,10 @@ class TestPRValidation:
                 "invalid_unvalidated_issue"
                 in mock_pr_obj.create_issue_comment.call_args[0][0].lower()
             )
+            assert (
+                call("@coderabbitai review")
+                not in mock_pr_obj.create_issue_comment.call_args_list
+            )
 
     def test_handle_pull_request_valid_removes_label(self, bot_env):
         bot = IssueAssignmentBot()
@@ -1338,6 +1349,71 @@ class TestPRValidation:
         with patch.object(bot, "validate_pr_issues", return_value=True):
             assert bot.handle_pull_request()
             mock_pr_obj.remove_from_labels.assert_called_once_with("invalid")
+            self.assert_review(mock_pr_obj)
+
+    def test_requests_review(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.event_name = "pull_request_target"
+        bot.load_event_payload(
+            {
+                "action": "opened",
+                "pull_request": {
+                    "number": 100,
+                    "user": {"login": "testuser"},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+        mock_pr_obj = Mock()
+        mock_pr_obj.labels = []
+        bot_env["repo"].get_pull.return_value = mock_pr_obj
+        with patch.object(bot, "validate_pr_issues", return_value=True):
+            assert bot.handle_pull_request()
+            self.assert_review(mock_pr_obj)
+
+    def test_skips_review_when_labeled(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.event_name = "pull_request_target"
+        bot.load_event_payload(
+            {
+                "action": "edited",
+                "pull_request": {
+                    "number": 100,
+                    "user": {"login": "testuser"},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+        mock_label = Mock()
+        mock_label.name = "ai-review"
+        mock_pr_obj = Mock()
+        mock_pr_obj.labels = [mock_label]
+        bot_env["repo"].get_pull.return_value = mock_pr_obj
+        with patch.object(bot, "validate_pr_issues", return_value=True):
+            assert bot.handle_pull_request()
+            mock_pr_obj.create_issue_comment.assert_not_called()
+            mock_pr_obj.add_to_labels.assert_not_called()
+
+    def test_keeps_label_on_review_error(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.event_name = "pull_request_target"
+        bot.load_event_payload(
+            {
+                "action": "opened",
+                "pull_request": {
+                    "number": 100,
+                    "user": {"login": "testuser"},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+        mock_pr_obj = Mock()
+        mock_pr_obj.labels = []
+        mock_pr_obj.create_issue_comment.side_effect = Exception("API error")
+        bot_env["repo"].get_pull.return_value = mock_pr_obj
+        with patch.object(bot, "validate_pr_issues", return_value=True):
+            assert not bot.handle_pull_request()
+            mock_pr_obj.add_to_labels.assert_called_once_with("ai-review")
 
     def test_workflow_has_members_read_permission(self):
         """Verify that the reusable workflow requests permission-members: read."""

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -78,7 +78,9 @@ OpenWISP repositories. The bot provides the following features:
   external contributors by flagging PRs that do not link a validated
   issue. PRs created by the configured GitHub App are exempt. The bot
   removes the ``invalid`` label once the PR is valid and closes unresolved
-  invalid PRs after 24 hours.
+  invalid PRs after 24 hours. For valid PRs, it applies the ``ai-review``
+  label and then requests a CodeRabbit review. The label prevents repeated
+  review requests.
 
 **How Stale PR Detection Works**
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [ ] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #745.

## Description of Changes

Valid pull requests receive the `ai-review` label before the bot requests a continuous CodeRabbit review. The label prevents duplicate requests, and invalid pull requests are excluded.

## Screenshot

N/A