### PR TITLE
[chores] Add width for select2 container

### DIFF
--- a/openwisp_utils/admin_theme/static/admin/css/openwisp.css
+++ b/openwisp_utils/admin_theme/static/admin/css/openwisp.css
@@ -484,6 +484,9 @@ select {
 .select2-container {
   min-width: 320px !important;
 }
+#main .form-row .select2-container {
+  max-width: 320px;
+}
 #main .select2-selection__arrow {
   height: 28px;
   top: 3px;


### PR DESCRIPTION
## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes
- Add width 320px to the select2 container so that long names won't affect the container width.
- Tested on openwisp-controller with this change to verify it is correctly targeted.

## Screenshot
<img width="1920" height="1072" alt="image" src="https://github.com/user-attachments/assets/79d107be-fc11-4fef-915d-693d7e7f84ef" />

