### PR TITLE
[ci] Changed CodeRabbit opt-in review to use label only #745

### DIFF
--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -458,8 +458,7 @@ class IssueAssignmentBot(GitHubBot):
                         print(f"Removed 'invalid' label from PR #{pr_number}")
                     if "ai-review" not in labels_lower:
                         pr_obj.add_to_labels("ai-review")
-                        pr_obj.create_issue_comment("@coderabbitai review")
-                        print(f"Requested CodeRabbit review for PR #{pr_number}")
+                        print(f"Added 'ai-review' label to PR #{pr_number}")
                 else:
                     if "invalid" not in labels_lower:
                         pr_obj.add_to_labels("invalid")

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, patch
 
 # Add the parent directory to path for importing bot modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -957,12 +957,9 @@ class TestExtractAllLinkedIssues:
 
 
 class TestPRValidation:
-    def assert_review(self, pr):
+    def assert_label(self, pr):
         pr.add_to_labels.assert_called_once_with("ai-review")
-        pr.create_issue_comment.assert_called_once_with("@coderabbitai review")
-        assert pr.method_calls.index(
-            call.add_to_labels("ai-review")
-        ) < pr.method_calls.index(call.create_issue_comment("@coderabbitai review"))
+        pr.create_issue_comment.assert_not_called()
 
     def test_get_issue_projects_success(self, bot_env):
         bot = IssueAssignmentBot()
@@ -1323,10 +1320,6 @@ class TestPRValidation:
                 "invalid_unvalidated_issue"
                 in mock_pr_obj.create_issue_comment.call_args[0][0].lower()
             )
-            assert (
-                call("@coderabbitai review")
-                not in mock_pr_obj.create_issue_comment.call_args_list
-            )
 
     def test_handle_pull_request_valid_removes_label(self, bot_env):
         bot = IssueAssignmentBot()
@@ -1349,9 +1342,9 @@ class TestPRValidation:
         with patch.object(bot, "validate_pr_issues", return_value=True):
             assert bot.handle_pull_request()
             mock_pr_obj.remove_from_labels.assert_called_once_with("invalid")
-            self.assert_review(mock_pr_obj)
+            self.assert_label(mock_pr_obj)
 
-    def test_requests_review(self, bot_env):
+    def test_adds_label(self, bot_env):
         bot = IssueAssignmentBot()
         bot.event_name = "pull_request_target"
         bot.load_event_payload(
@@ -1369,9 +1362,9 @@ class TestPRValidation:
         bot_env["repo"].get_pull.return_value = mock_pr_obj
         with patch.object(bot, "validate_pr_issues", return_value=True):
             assert bot.handle_pull_request()
-            self.assert_review(mock_pr_obj)
+            self.assert_label(mock_pr_obj)
 
-    def test_skips_review_when_labeled(self, bot_env):
+    def test_skips_label_when_labeled(self, bot_env):
         bot = IssueAssignmentBot()
         bot.event_name = "pull_request_target"
         bot.load_event_payload(
@@ -1393,27 +1386,6 @@ class TestPRValidation:
             assert bot.handle_pull_request()
             mock_pr_obj.create_issue_comment.assert_not_called()
             mock_pr_obj.add_to_labels.assert_not_called()
-
-    def test_keeps_label_on_review_error(self, bot_env):
-        bot = IssueAssignmentBot()
-        bot.event_name = "pull_request_target"
-        bot.load_event_payload(
-            {
-                "action": "opened",
-                "pull_request": {
-                    "number": 100,
-                    "user": {"login": "testuser"},
-                    "body": "Fixes #123",
-                },
-            }
-        )
-        mock_pr_obj = Mock()
-        mock_pr_obj.labels = []
-        mock_pr_obj.create_issue_comment.side_effect = Exception("API error")
-        bot_env["repo"].get_pull.return_value = mock_pr_obj
-        with patch.object(bot, "validate_pr_issues", return_value=True):
-            assert not bot.handle_pull_request()
-            mock_pr_obj.add_to_labels.assert_called_once_with("ai-review")
 
     def test_workflow_has_members_read_permission(self):
         """Verify that the reusable workflow requests permission-members: read."""

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -79,8 +79,8 @@ OpenWISP repositories. The bot provides the following features:
   issue. PRs created by the configured GitHub App are exempt. The bot
   removes the ``invalid`` label once the PR is valid and closes unresolved
   invalid PRs after 24 hours. For valid PRs, it applies the ``ai-review``
-  label and then requests a CodeRabbit review. The label prevents repeated
-  review requests.
+  label, which triggers a CodeRabbit review. The label prevents repeated
+  reviews.
 
 **How Stale PR Detection Works**
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Related to #745.

## Description of Changes

Removes the manual `@coderabbitai review` comment because it's ineffective (coderabbit ignores bots). 
CodeRabbit now starts continuous reviews when the autoassign bot applies the `ai-review` label to valid pull requests. This approach has proven to work in this PR.