### PR TITLE
[ci] Excluded release and bot PRs from CodeRabbit reviews #745

### DIFF
--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -429,6 +429,7 @@ class IssueAssignmentBot(GitHubBot):
             action = self.event_payload.get("action", "")
             pr_number = pr.get("number")
             pr_author = pr.get("user", {}).get("login", "")
+            pr_title = pr.get("title", "")
             pr_body = pr.get("body", "")
             if not all([pr_number, pr_author]):
                 print("Missing required PR data")
@@ -456,7 +457,11 @@ class IssueAssignmentBot(GitHubBot):
                     if "invalid" in labels_lower:
                         pr_obj.remove_from_labels("invalid")
                         print(f"Removed 'invalid' label from PR #{pr_number}")
-                    if "ai-review" not in labels_lower:
+                    skip_label = (
+                        pr_author.lower() == "dependabot[bot]"
+                        or pr_title.lower().startswith(("[release]", "[backport]"))
+                    )
+                    if "ai-review" not in labels_lower and not skip_label:
                         pr_obj.add_to_labels("ai-review")
                         print(f"Added 'ai-review' label to PR #{pr_number}")
                 else:

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -1364,6 +1364,35 @@ class TestPRValidation:
             assert bot.handle_pull_request()
             self.assert_label(mock_pr_obj)
 
+    @pytest.mark.parametrize(
+        "author,title",
+        [
+            ("dependabot[bot]", "Bump a dependency"),
+            ("testuser", "[release] Version 1.3.1"),
+            ("testuser", "[backport] Fixed regression"),
+        ],
+    )
+    def test_skips_excluded_prs(self, author, title, bot_env):
+        bot = IssueAssignmentBot()
+        bot.event_name = "pull_request_target"
+        bot.load_event_payload(
+            {
+                "action": "opened",
+                "pull_request": {
+                    "number": 100,
+                    "title": title,
+                    "user": {"login": author},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+        mock_pr_obj = Mock()
+        mock_pr_obj.labels = []
+        bot_env["repo"].get_pull.return_value = mock_pr_obj
+        with patch.object(bot, "validate_pr_issues", return_value=True):
+            assert bot.handle_pull_request()
+            mock_pr_obj.add_to_labels.assert_not_called()
+
     def test_skips_label_when_labeled(self, bot_env):
         bot = IssueAssignmentBot()
         bot.event_name = "pull_request_target"

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -80,7 +80,8 @@ OpenWISP repositories. The bot provides the following features:
   removes the ``invalid`` label once the PR is valid and closes unresolved
   invalid PRs after 24 hours. For valid PRs, it applies the ``ai-review``
   label, which triggers a CodeRabbit review. The label prevents repeated
-  reviews.
+  reviews. Dependabot PRs and PRs whose titles begin with ``[release]`` or
+  ``[backport]`` do not receive the label.
 
 **How Stale PR Detection Works**
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Related to #745.

## Description of Changes

Prevents the autoassign bot from adding `ai-review` to Dependabot PRs and PRs whose titles begin with `[release]` or `[backport]`.

## Screenshot

N/A