### PR TITLE
[ci] Bots: updated and synced invalid issue/PR messages

### DIFF
--- a/.github/actions/bot-autoassign/base.py
+++ b/.github/actions/bot-autoassign/base.py
@@ -187,11 +187,7 @@ class GitHubBot:
         )
         return False
 
-    def validate_pr_issues(self, pr):
-        """Validate if a pull request is from an exempt user or references a validated issue."""
-        if not self.github_validation or not self.repository_name:
-            print("GitHub validation client or repository name not initialized")
-            return False
+    def is_pr_author_exempt(self, pr):
         pr_author = (
             pr.user.login
             if pr.user and isinstance(getattr(pr.user, "login", None), str)
@@ -215,6 +211,15 @@ class GitHubBot:
                 f"Author {pr_author} is exempt due to association: "
                 f"{author_association}. Proceeding."
             )
+            return True
+        return False
+
+    def validate_pr_issues(self, pr):
+        """Validate if a pull request is from an exempt user or references a validated issue."""
+        if not self.github_validation or not self.repository_name:
+            print("GitHub validation client or repository name not initialized")
+            return False
+        if self.is_pr_author_exempt(pr):
             return True
         pr_body = pr.body if isinstance(pr.body, str) else ""
         linked_issues = extract_all_linked_issues(pr_body, self.repository_name)

--- a/.github/actions/bot-autoassign/base.py
+++ b/.github/actions/bot-autoassign/base.py
@@ -6,6 +6,7 @@ from utils import extract_all_linked_issues
 MAINTAINER_ROLES = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 DEFAULT_EXCLUDE_PR_AUTHORS = "dependabot[bot]"
 MAX_VALIDATION_ISSUES = 10
+CONTRIBUTING_GUIDELINES_URL = "https://openwisp.io/docs/dev/developer/contributing.html"
 # Stable ProjectV2 node IDs for the OpenWISP contributor boards.
 # These IDs never change even if a board is renamed.
 REQUIRED_CONTRIBUTOR_PROJECT_IDS = frozenset(
@@ -56,6 +57,27 @@ class GitHubBot:
 
     def load_event_payload(self, event_payload):
         self.event_payload = event_payload
+
+    def get_unvalidated_issue_message(self, context):
+        return (
+            f"{context}\n\n"
+            "An issue is considered validated when it is open, has at least one "
+            "label other than `invalid` or `wontfix`, and is assigned to either the "
+            "[OpenWISP Contributor's Board]"
+            "(https://github.com/orgs/openwisp/projects/42/views/1) or the "
+            "[OpenWISP Priorities for next releases]"
+            "(https://github.com/orgs/openwisp/projects/37/views/1).\n\n"
+            "Please refer to the [OpenWISP Contributing Guidelines]"
+            f"({CONTRIBUTING_GUIDELINES_URL}) for more information.\n\n"
+            "Please see the [OpenWISP Anti AI Spam Policy]"
+            "(https://openwisp.io/docs/dev/general/code-of-conduct.html).\n\n"
+            "Feel free to join the [OpenWISP dev chatroom]"
+            "(https://matrix.to/#/#openwisp_development:gitter.im) "
+            "to coordinate with the development team.\n\n"
+            "Pull requests from external contributors that target an unvalidated "
+            "issue are flagged as invalid and closed automatically if not resolved "
+            "within 24 hours."
+        )
 
     def get_issue_projects(self, owner, repo_name, issue_number):
         query = """
@@ -278,11 +300,10 @@ class GitHubBot:
     def get_invalid_unvalidated_issue_comment(self, pr_author):
         """Returns the comment body warning that the PR is invalid/unvalidated."""
         greeting = f"Hi @{pr_author},\n\n" if pr_author else "Hi,\n\n"
-        return (
-            "<!-- bot:invalid_unvalidated_issue -->\n\n"
+        message = self.get_unvalidated_issue_message(
             f"{greeting}"
             "Thank you for your interest in contributing to OpenWISP.\n\n"
-            "This pull request has been flagged because external contributors "
+            "This pull request has been flagged as invalid because external contributors "
             "must target an issue validated by maintainers before requesting "
             "review.\n\n"
             "Please link this pull request to a validated issue by adding "
@@ -292,18 +313,10 @@ class GitHubBot:
             "repository.\n\n"
             "If there is no validated issue yet, please open one first and wait "
             "for maintainer validation before continuing with this pull "
-            "request.\n\n"
-            "An issue is considered validated when it is open, has an appropriate "
-            "label other than `invalid` or `wontfix`, and is assigned to one of "
-            "the project boards mentioned in the "
-            "[OpenWISP Contributing Guidelines]"
-            "(https://openwisp.io/docs/dev/developer/contributing.html).\n\n"
-            "Please see the [OpenWISP Anti AI Spam Policy]"
-            "(https://openwisp.io/docs/dev/general/code-of-conduct.html).\n\n"
-            "Feel free to join the [OpenWISP dev chatroom]"
-            "(https://matrix.to/#/#openwisp_development:gitter.im) "
-            "to coordinate with the development team.\n\n"
-            "If this is not resolved within 24 hours, this pull request "
-            "will be closed automatically. "
+            "request."
+        )
+        return (
+            "<!-- bot:invalid_unvalidated_issue -->\n\n"
+            f"{message}\n\n"
             "Thank you for your understanding."
         )

--- a/.github/actions/bot-autoassign/base.py
+++ b/.github/actions/bot-autoassign/base.py
@@ -62,7 +62,7 @@ class GitHubBot:
         return (
             f"{context}\n\n"
             "An issue is considered validated when it is open, has at least one "
-            "label other than `invalid` or `wontfix`, and is assigned to either the "
+            "label, has no `invalid` or `wontfix` label, and is assigned to either the "
             "[OpenWISP Contributor's Board]"
             "(https://github.com/orgs/openwisp/projects/42/views/1) or the "
             "[OpenWISP Priorities for next releases]"

--- a/.github/actions/bot-autoassign/base.py
+++ b/.github/actions/bot-autoassign/base.py
@@ -132,6 +132,61 @@ class GitHubBot:
 
         return projects
 
+    def validate_issue(self, owner, repo_name, issue_number):
+        if not self.github_validation:
+            print("GitHub validation client not initialized")
+            return False
+        try:
+            target_repo = self.github_validation.get_repo(f"{owner}/{repo_name}")
+            issue = target_repo.get_issue(issue_number)
+        except Exception as e:
+            if isinstance(e, GithubException) and e.status == 404:
+                print(
+                    f"Issue {owner}/{repo_name}#{issue_number} not found, skipping validation."
+                )
+                return False
+            print(f"Error fetching issue {owner}/{repo_name}#{issue_number}: {e}")
+            raise
+        if issue.pull_request:
+            print(
+                f"Reference {owner}/{repo_name}#{issue_number} is a pull request, skipping validation."
+            )
+            return False
+        if issue.state != "open":
+            print(
+                f"Issue {owner}/{repo_name}#{issue_number} is not open, skipping validation."
+            )
+            return False
+        issue_labels = [label.name.lower() for label in issue.labels]
+        valid_labels = [lbl for lbl in issue_labels if lbl not in INVALID_ISSUE_LABELS]
+        if not valid_labels:
+            print(
+                f"Issue {owner}/{repo_name}#{issue_number} has no valid labels, skipping validation."
+            )
+            return False
+        if any(lbl in INVALID_ISSUE_LABELS for lbl in issue_labels):
+            print(
+                f"Issue {owner}/{repo_name}#{issue_number} contains "
+                "invalid/wontfix label, skipping validation."
+            )
+            return False
+        try:
+            projects = self.get_issue_projects(owner, repo_name, issue_number)
+        except Exception as e:
+            print(
+                f"Error fetching projects for issue {owner}/{repo_name}#{issue_number}: {e}"
+            )
+            raise
+        if REQUIRED_CONTRIBUTOR_PROJECT_IDS.intersection(projects):
+            print(f"Issue {owner}/{repo_name}#{issue_number} is validated.")
+            return True
+        print(
+            f"Issue {owner}/{repo_name}#{issue_number} is not assigned "
+            f"to any required project (found: {projects or 'none'}), "
+            "skipping validation."
+        )
+        return False
+
     def validate_pr_issues(self, pr):
         """Validate if a pull request is from an exempt user or references a validated issue."""
         if not self.github_validation or not self.repository_name:
@@ -179,63 +234,11 @@ class GitHubBot:
                     f"to organization {current_org}, skipping validation."
                 )
                 continue
-            try:
-                target_repo = self.github_validation.get_repo(f"{owner}/{repo_name}")
-                issue = target_repo.get_issue(issue_number)
-            except Exception as e:
-                if isinstance(e, GithubException) and e.status == 404:
-                    print(
-                        f"Issue {owner}/{repo_name}#{issue_number} not found, skipping validation."
-                    )
-                    continue
-                print(f"Error fetching issue {owner}/{repo_name}#{issue_number}: {e}")
-                raise
-            if issue.pull_request:
-                print(
-                    f"Reference {owner}/{repo_name}#{issue_number} is a pull request, skipping validation."
-                )
-                continue
-            if issue.state != "open":
-                print(
-                    f"Issue {owner}/{repo_name}#{issue_number} is not open, skipping validation."
-                )
-                continue
-            issue_labels = [label.name.lower() for label in issue.labels]
-            valid_labels = [
-                lbl for lbl in issue_labels if lbl not in INVALID_ISSUE_LABELS
-            ]
-            if not valid_labels:
-                print(
-                    f"Issue {owner}/{repo_name}#{issue_number} has no valid labels, skipping validation."
-                )
-                continue
-            if any(lbl in INVALID_ISSUE_LABELS for lbl in issue_labels):
-                print(
-                    f"Issue {owner}/{repo_name}#{issue_number} contains "
-                    "invalid/wontfix label, skipping validation."
-                )
-                continue
-            try:
-                projects = self.get_issue_projects(owner, repo_name, issue_number)
-            except Exception as e:
-                print(
-                    f"Error fetching projects for issue {owner}/{repo_name}#{issue_number}: {e}"
-                )
-                raise
-            has_valid_project = bool(
-                REQUIRED_CONTRIBUTOR_PROJECT_IDS.intersection(projects)
-            )
-            if has_valid_project:
+            if self.validate_issue(owner, repo_name, issue_number):
                 print(
                     f"Issue {owner}/{repo_name}#{issue_number} is validated. PR is valid."
                 )
                 return True
-            else:
-                print(
-                    f"Issue {owner}/{repo_name}#{issue_number} is not assigned "
-                    f"to any required project (found: {projects or 'none'}), "
-                    "skipping validation."
-                )
         return False
 
     def get_bot_comment(self, pr, comment_type, after_date=None, issue_comments=None):

--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -112,6 +112,13 @@ class IssueAssignmentBot(GitHubBot):
         try:
             contributing_url = self.get_contributing_guidelines_url()
             issue = self.repo.get_issue(issue_number)
+            owner, repo_name = self.repository_name.split("/")
+            if not self.validate_issue(owner, repo_name, issue_number):
+                issue.create_comment(
+                    self.get_unvalidated_issue_assignment_request_comment(commenter)
+                )
+                print(f"Posted unvalidated issue response to issue #{issue_number}")
+                return True
             issue_type = self.detect_issue_type(issue)
             suggested_keyword = None
             detection_reason = ""
@@ -204,6 +211,25 @@ class IssueAssignmentBot(GitHubBot):
             print(f"Error responding to assignment request: {e}")
             return False
 
+    def get_unvalidated_issue_assignment_request_comment(self, commenter):
+        return (
+            f"Hi @{commenter},\n\n"
+            "Thank you for your interest in contributing to OpenWISP.\n\n"
+            "This issue has not been validated as available for new or occasional "
+            "contributors and is reserved for experienced contributors.\n\n"
+            "An issue is considered validated when it is open, has an appropriate "
+            "label other than `invalid` or `wontfix`, and is assigned to either the "
+            "[OpenWISP Contributor's Board]"
+            "(https://github.com/orgs/openwisp/projects/42/views/1) or the "
+            "[OpenWISP Priorities for next releases]"
+            "(https://github.com/orgs/openwisp/projects/37/views/1).\n\n"
+            "Pull requests from external contributors that target an unvalidated "
+            "issue are flagged as invalid and closed automatically if not resolved "
+            "within 24 hours.\n\n"
+            "Please see the [OpenWISP Contributing Guidelines]"
+            "(https://openwisp.io/docs/dev/developer/contributing.html)."
+        )
+
     def _cannot_auto_assign_message(self, pr_author, pr_number):
         return (
             f"Hi @{pr_author} 👋,\n\n"
@@ -256,6 +282,11 @@ class IssueAssignmentBot(GitHubBot):
                     f" this issue (#{issue_number}). Please open a PR"
                     f" linking to this issue (e.g. `Fixes #{issue_number}`)"
                     f" and then comment `@{self.bot_username} assign` again."
+                )
+                return True
+            if not self.validate_pr_issues(pr):
+                print(
+                    f"PR #{pr.number} for #{issue_number} is invalid, ignoring bot command"
                 )
                 return True
             issue.add_to_assignees(commenter)

--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -284,11 +284,11 @@ class IssueAssignmentBot(GitHubBot):
                     f" and then comment `@{self.bot_username} assign` again."
                 )
                 return True
-            if not self.validate_pr_issues(pr):
-                print(
-                    f"PR #{pr.number} for #{issue_number} is invalid, ignoring bot command"
-                )
-                return True
+            if not self.is_pr_author_exempt(pr):
+                owner, repo_name = self.repository_name.split("/")
+                if not self.validate_issue(owner, repo_name, issue_number):
+                    print(f"Issue #{issue_number} is invalid, ignoring bot command")
+                    return True
             issue.add_to_assignees(commenter)
             verified = verify_assignment(self.repo, issue_number, commenter)
             if verified is True:

--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -1,6 +1,6 @@
 import re
 
-from base import GitHubBot
+from base import CONTRIBUTING_GUIDELINES_URL, GitHubBot
 from utils import (
     extract_linked_issues,
     find_open_pr_for_issue,
@@ -34,9 +34,6 @@ class IssueAssignmentBot(GitHubBot):
             r"\bcan you assign this to me\b",
         ]
         return any(re.search(pattern, comment_lower) for pattern in assignment_patterns)
-
-    def get_contributing_guidelines_url(self):
-        return "https://openwisp.io/docs/stable/developer/contributing.html"
 
     def detect_issue_type(self, issue):
         """Analyzes labels, title and body.
@@ -110,7 +107,7 @@ class IssueAssignmentBot(GitHubBot):
             print("GitHub client not initialized")
             return False
         try:
-            contributing_url = self.get_contributing_guidelines_url()
+            contributing_url = CONTRIBUTING_GUIDELINES_URL
             issue = self.repo.get_issue(issue_number)
             owner, repo_name = self.repository_name.split("/")
             if not self.validate_issue(owner, repo_name, issue_number):
@@ -212,22 +209,11 @@ class IssueAssignmentBot(GitHubBot):
             return False
 
     def get_unvalidated_issue_assignment_request_comment(self, commenter):
-        return (
+        return self.get_unvalidated_issue_message(
             f"Hi @{commenter},\n\n"
             "Thank you for your interest in contributing to OpenWISP.\n\n"
             "This issue has not been validated as available for new or occasional "
-            "contributors and is reserved for experienced contributors.\n\n"
-            "An issue is considered validated when it is open, has an appropriate "
-            "label other than `invalid` or `wontfix`, and is assigned to either the "
-            "[OpenWISP Contributor's Board]"
-            "(https://github.com/orgs/openwisp/projects/42/views/1) or the "
-            "[OpenWISP Priorities for next releases]"
-            "(https://github.com/orgs/openwisp/projects/37/views/1).\n\n"
-            "Pull requests from external contributors that target an unvalidated "
-            "issue are flagged as invalid and closed automatically if not resolved "
-            "within 24 hours.\n\n"
-            "Please see the [OpenWISP Contributing Guidelines]"
-            "(https://openwisp.io/docs/dev/developer/contributing.html)."
+            "contributors and is reserved for experienced contributors."
         )
 
     def _cannot_auto_assign_message(self, pr_author, pr_number):

--- a/.github/actions/bot-autoassign/issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/issue_assignment_bot.py
@@ -305,7 +305,9 @@ class IssueAssignmentBot(GitHubBot):
             print(f"Error handling bot assign command: {e}")
             return False
 
-    def auto_assign_issues_from_pr(self, pr_number, pr_author, pr_body, max_issues=10):
+    def auto_assign_issues_from_pr(
+        self, pr_number, pr_author, pr_body, max_issues=10, validate_issues=False
+    ):
         if not self.repo:
             print("GitHub client not initialized")
             return []
@@ -321,12 +323,20 @@ class IssueAssignmentBot(GitHubBot):
                     " to avoid rate limits"
                 )
             assigned_issues = []
+            owner, repo_name = self.repository_name.split("/")
             for issue_number, issue in get_valid_linked_issues(
                 self.repo, self.repository_name, linked_issues
             ):
                 if len(assigned_issues) >= max_issues:
                     break
                 try:
+                    if validate_issues and not self.validate_issue(
+                        owner, repo_name, issue_number
+                    ):
+                        print(
+                            f"Issue #{issue_number} is invalid, skipping auto-assignment"
+                        )
+                        continue
                     if getattr(issue, "state", "open") == "closed":
                         print(
                             f"Issue #{issue_number} is closed, skipping"
@@ -459,12 +469,18 @@ class IssueAssignmentBot(GitHubBot):
                 return True
             if action in ["opened", "reopened", "edited", "ready_for_review"]:
                 pr_obj = self.repo.get_pull(pr_number)
-                is_valid = self.validate_pr_issues(pr_obj)
+                is_exempt = self.is_pr_author_exempt(pr_obj)
+                is_valid = is_exempt or self.validate_pr_issues(pr_obj)
                 # Cross-repo issues are intentionally excluded from auto-assignment
                 # because when multiple PRs in different repos are created for a
                 # single issue, it's likely that multiple people will work on it
                 if is_valid:
-                    self.auto_assign_issues_from_pr(pr_number, pr_author, pr_body)
+                    self.auto_assign_issues_from_pr(
+                        pr_number,
+                        pr_author,
+                        pr_body,
+                        validate_issues=not is_exempt,
+                    )
                 labels_lower = set()
                 try:
                     labels_lower = {label.name.lower() for label in pr_obj.labels}

--- a/.github/actions/bot-autoassign/pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/pr_reopen_bot.py
@@ -86,7 +86,16 @@ class PRReopenBot(GitHubBot):
                 print("Missing required PR data")
                 return False
             print(f"Handling PR #{pr_number}" f" reopen by {pr_author}")
-            reassigned = self.reassign_issues_to_author(pr_number, pr_author, pr_body)
+            current_pr = self.repo.get_pull(pr_number)
+            if not self.validate_pr_issues(current_pr):
+                print(f"PR #{pr_number} is invalid, ignoring reassignment")
+                return True
+            current_pr_body = (
+                current_pr.body if isinstance(current_pr.body, str) else pr_body
+            )
+            reassigned = self.reassign_issues_to_author(
+                pr_number, pr_author, current_pr_body
+            )
             self.remove_stale_label(pr_number)
             print(f"Reassigned {len(reassigned)}" f" issues to {pr_author}")
             return True
@@ -132,6 +141,9 @@ class PRActivityBot(GitHubBot):
             pr = self.repo.get_pull(pr_number)
             if not pr.user or not user_in_logins(commenter, [pr.user.login]):
                 print("Comment not from PR author, skipping")
+                return True
+            if not self.validate_pr_issues(pr):
+                print(f"PR #{pr_number} is invalid, ignoring reassignment")
                 return True
             labels = [label.name for label in pr.get_labels()]
             if "stale" not in labels:

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -752,7 +752,10 @@ class TestHandleBotAssignRequest:
     @pytest.fixture(autouse=True)
     def valid_pr(self, monkeypatch):
         monkeypatch.setattr(
-            IssueAssignmentBot, "validate_pr_issues", Mock(return_value=True)
+            IssueAssignmentBot, "is_pr_author_exempt", Mock(return_value=False)
+        )
+        monkeypatch.setattr(
+            IssueAssignmentBot, "validate_issue", Mock(return_value=True)
         )
 
     def test_assigns_when_open_pr_exists(self, bot_env):
@@ -771,7 +774,8 @@ class TestHandleBotAssignRequest:
 
     def test_ignores_invalid_pr(self, bot_env):
         bot = IssueAssignmentBot()
-        bot.validate_pr_issues = Mock(return_value=False)
+        bot.is_pr_author_exempt = Mock(return_value=False)
+        bot.validate_issue = Mock(return_value=False)
         mock_issue = _make_issue_with_assignment("contributor")
         bot_env["repo"].get_issue.return_value = mock_issue
         mock_pr = _make_search_result(200, "Fixes #123")
@@ -779,7 +783,7 @@ class TestHandleBotAssignRequest:
 
         assert bot.handle_bot_assign_request(123, "contributor")
 
-        bot.validate_pr_issues.assert_called_once_with(mock_pr.as_pull_request())
+        bot.validate_issue.assert_called_once_with("openwisp", "openwisp-utils", 123)
         mock_issue.add_to_assignees.assert_not_called()
         mock_issue.create_comment.assert_not_called()
 
@@ -883,7 +887,8 @@ class TestHandleBotAssignRequest:
 class TestHandleIssueCommentBotCommand:
     def test_bot_command_triggers_assign(self, bot_env):
         bot = IssueAssignmentBot()
-        bot.validate_pr_issues = Mock(return_value=True)
+        bot.is_pr_author_exempt = Mock(return_value=False)
+        bot.validate_issue = Mock(return_value=True)
         bot.load_event_payload(
             {
                 "issue": {"number": 123, "pull_request": None},

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -159,6 +159,20 @@ class TestRespondToAssignment:
         assert "not been validated" in comment_text
         assert "OpenWISP Contributor's Board" in comment_text
         assert "closed automatically" in comment_text
+        assert "Please refer to the [OpenWISP Contributing Guidelines]" in comment_text
+
+    def test_unvalidated_messages_share_requirements(self, bot_env):
+        bot = IssueAssignmentBot()
+        issue_comment = bot.get_unvalidated_issue_assignment_request_comment("testuser")
+        pr_comment = bot.get_invalid_unvalidated_issue_comment("testuser")
+        assert "This pull request has been flagged as invalid" in pr_comment
+        for comment in (issue_comment, pr_comment):
+            assert "An issue is considered validated" in comment
+            assert "OpenWISP Contributor's Board" in comment
+            assert "Please refer to the [OpenWISP Contributing Guidelines]" in comment
+            assert "OpenWISP Anti AI Spam Policy" in comment
+            assert "OpenWISP dev chatroom" in comment
+            assert "Pull requests from external contributors" in comment
 
     def test_stays_silent_when_issue_validation_fails(self, bot_env):
         bot = IssueAssignmentBot()

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 # Add the parent directory to path for importing bot modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -168,6 +168,9 @@ class TestRespondToAssignment:
         assert "This pull request has been flagged as invalid" in pr_comment
         for comment in (issue_comment, pr_comment):
             assert "An issue is considered validated" in comment
+            assert (
+                "has at least one label, has no `invalid` or `wontfix` label" in comment
+            )
             assert "OpenWISP Contributor's Board" in comment
             assert "Please refer to the [OpenWISP Contributing Guidelines]" in comment
             assert "OpenWISP Anti AI Spam Policy" in comment
@@ -268,6 +271,30 @@ def _make_search_result(number, body, user_login="contributor"):
 
 
 class TestAutoAssignIssuesFromPR:
+    def test_validates_each_issue_before_assigning(self, bot_env):
+        bot = IssueAssignmentBot()
+        issues_by_number = {
+            123: _make_issue_with_assignment("testuser"),
+            456: _make_issue_with_assignment("testuser"),
+        }
+        bot_env["repo"].get_issue.side_effect = lambda n: issues_by_number[n]
+        bot.validate_issue = Mock(side_effect=[False, True])
+        assigned = bot.auto_assign_issues_from_pr(
+            100,
+            "testuser",
+            "This PR fixes #123 and closes #456",
+            validate_issues=True,
+        )
+        assert assigned == [456]
+        bot.validate_issue.assert_has_calls(
+            [
+                call("openwisp", "openwisp-utils", 123),
+                call("openwisp", "openwisp-utils", 456),
+            ]
+        )
+        issues_by_number[123].add_to_assignees.assert_not_called()
+        issues_by_number[456].add_to_assignees.assert_called_once_with("testuser")
+
     def test_success(self, bot_env):
         bot = IssueAssignmentBot()
         issues_by_number = {
@@ -563,6 +590,53 @@ class TestHandleIssueComment:
 
 
 class TestHandlePullRequest:
+    def test_validates_each_issue_before_auto_assign(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.load_event_payload(
+            {
+                "action": "opened",
+                "pull_request": {
+                    "number": 100,
+                    "user": {"login": "testuser"},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+        mock_pr = Mock()
+        mock_pr.labels = []
+        bot_env["repo"].get_pull.return_value = mock_pr
+        bot.is_pr_author_exempt = Mock(return_value=False)
+        bot.validate_pr_issues = Mock(return_value=True)
+        bot.auto_assign_issues_from_pr = Mock()
+        assert bot.handle_pull_request()
+        bot.auto_assign_issues_from_pr.assert_called_once_with(
+            100, "testuser", "Fixes #123", validate_issues=True
+        )
+
+    def test_skips_per_issue_validation_for_exempt_author(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.load_event_payload(
+            {
+                "action": "opened",
+                "pull_request": {
+                    "number": 100,
+                    "user": {"login": "testuser"},
+                    "body": "Fixes #123",
+                },
+            }
+        )
+        mock_pr = Mock()
+        mock_pr.labels = []
+        bot_env["repo"].get_pull.return_value = mock_pr
+        bot.is_pr_author_exempt = Mock(return_value=True)
+        bot.validate_pr_issues = Mock()
+        bot.auto_assign_issues_from_pr = Mock()
+        assert bot.handle_pull_request()
+        bot.validate_pr_issues.assert_not_called()
+        bot.auto_assign_issues_from_pr.assert_called_once_with(
+            100, "testuser", "Fixes #123", validate_issues=False
+        )
+
     def test_opened(self, bot_env):
         bot = IssueAssignmentBot()
         bot.load_event_payload(
@@ -577,7 +651,9 @@ class TestHandlePullRequest:
         )
         mock_issue = _make_issue_with_assignment("testuser")
         bot_env["repo"].get_issue.return_value = mock_issue
+        bot.is_pr_author_exempt = MagicMock(return_value=False)
         bot.validate_pr_issues = MagicMock(return_value=True)
+        bot.validate_issue = MagicMock(return_value=True)
         assert bot.handle_pull_request()
         mock_issue.add_to_assignees.assert_called_once_with("testuser")
 

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -154,9 +154,7 @@ class TestRespondToAssignment:
         mock_issue.title = "Test issue"
         mock_issue.body = "Test body"
         bot_env["repo"].get_issue.return_value = mock_issue
-
         assert bot.respond_to_assignment_request(123, "testuser")
-
         comment_text = mock_issue.create_comment.call_args[0][0]
         assert "not been validated" in comment_text
         assert "OpenWISP Contributor's Board" in comment_text
@@ -170,9 +168,7 @@ class TestRespondToAssignment:
         mock_issue.title = "Test issue"
         mock_issue.body = "Test body"
         bot_env["repo"].get_issue.return_value = mock_issue
-
         assert not bot.respond_to_assignment_request(123, "testuser")
-
         mock_issue.create_comment.assert_not_called()
 
     def test_success_bug_detected(self, bot_env):
@@ -780,9 +776,7 @@ class TestHandleBotAssignRequest:
         bot_env["repo"].get_issue.return_value = mock_issue
         mock_pr = _make_search_result(200, "Fixes #123")
         bot_env["github"].search_issues.return_value = [mock_pr]
-
         assert bot.handle_bot_assign_request(123, "contributor")
-
         bot.validate_issue.assert_called_once_with("openwisp", "openwisp-utils", 123)
         mock_issue.add_to_assignees.assert_not_called()
         mock_issue.create_comment.assert_not_called()

--- a/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_issue_assignment_bot.py
@@ -130,6 +130,7 @@ class TestExtractLinkedIssues:
 class TestRespondToAssignment:
     def test_success_no_type_detected(self, bot_env):
         bot = IssueAssignmentBot()
+        bot.validate_issue = Mock(return_value=True)
         mock_issue = Mock()
         mock_issue.labels = []
         mock_issue.title = "Test issue title"
@@ -145,8 +146,38 @@ class TestRespondToAssignment:
         assert f"`Closes #{123}`" in comment_text
         assert f"`Fixes #{123}`" in comment_text
 
+    def test_replies_to_unvalidated_issue(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.validate_issue = Mock(return_value=False)
+        mock_issue = Mock()
+        mock_issue.labels = []
+        mock_issue.title = "Test issue"
+        mock_issue.body = "Test body"
+        bot_env["repo"].get_issue.return_value = mock_issue
+
+        assert bot.respond_to_assignment_request(123, "testuser")
+
+        comment_text = mock_issue.create_comment.call_args[0][0]
+        assert "not been validated" in comment_text
+        assert "OpenWISP Contributor's Board" in comment_text
+        assert "closed automatically" in comment_text
+
+    def test_stays_silent_when_issue_validation_fails(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.validate_issue = Mock(side_effect=GithubException(500, "error", None))
+        mock_issue = Mock()
+        mock_issue.labels = []
+        mock_issue.title = "Test issue"
+        mock_issue.body = "Test body"
+        bot_env["repo"].get_issue.return_value = mock_issue
+
+        assert not bot.respond_to_assignment_request(123, "testuser")
+
+        mock_issue.create_comment.assert_not_called()
+
     def test_success_bug_detected(self, bot_env):
         bot = IssueAssignmentBot()
+        bot.validate_issue = Mock(return_value=True)
         mock_label = Mock()
         mock_label.name = "bug"
         mock_issue = Mock()
@@ -160,6 +191,7 @@ class TestRespondToAssignment:
 
     def test_success_feature_detected(self, bot_env):
         bot = IssueAssignmentBot()
+        bot.validate_issue = Mock(return_value=True)
         mock_label = Mock()
         mock_label.name = "enhancement"
         mock_issue = Mock()
@@ -717,6 +749,12 @@ class TestIsBotAssignCommand:
 
 
 class TestHandleBotAssignRequest:
+    @pytest.fixture(autouse=True)
+    def valid_pr(self, monkeypatch):
+        monkeypatch.setattr(
+            IssueAssignmentBot, "validate_pr_issues", Mock(return_value=True)
+        )
+
     def test_assigns_when_open_pr_exists(self, bot_env):
         bot = IssueAssignmentBot()
         mock_issue = _make_issue_with_assignment("contributor")
@@ -730,6 +768,20 @@ class TestHandleBotAssignRequest:
         comment = mock_issue.create_comment.call_args[0][0]
         assert "assigned to @contributor" in comment
         assert "PR #200" in comment
+
+    def test_ignores_invalid_pr(self, bot_env):
+        bot = IssueAssignmentBot()
+        bot.validate_pr_issues = Mock(return_value=False)
+        mock_issue = _make_issue_with_assignment("contributor")
+        bot_env["repo"].get_issue.return_value = mock_issue
+        mock_pr = _make_search_result(200, "Fixes #123")
+        bot_env["github"].search_issues.return_value = [mock_pr]
+
+        assert bot.handle_bot_assign_request(123, "contributor")
+
+        bot.validate_pr_issues.assert_called_once_with(mock_pr.as_pull_request())
+        mock_issue.add_to_assignees.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
 
     def test_replies_when_no_open_pr(self, bot_env):
         bot = IssueAssignmentBot()
@@ -831,6 +883,7 @@ class TestHandleBotAssignRequest:
 class TestHandleIssueCommentBotCommand:
     def test_bot_command_triggers_assign(self, bot_env):
         bot = IssueAssignmentBot()
+        bot.validate_pr_issues = Mock(return_value=True)
         bot.load_event_payload(
             {
                 "issue": {"number": 123, "pull_request": None},

--- a/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
@@ -157,9 +157,7 @@ class TestPRReopenBot:
         )
         mock_pr = Mock()
         bot_env["repo"].get_pull.return_value = mock_pr
-
         assert bot.handle_pr_reopen()
-
         bot.validate_pr_issues.assert_called_once_with(mock_pr)
         bot_env["repo"].get_issue.assert_not_called()
         mock_pr.remove_from_labels.assert_not_called()
@@ -260,9 +258,7 @@ class TestPRActivityBot:
         mock_pr.user.login = "testuser"
         mock_pr.get_labels.return_value = []
         bot_env["repo"].get_pull.return_value = mock_pr
-
         assert bot.handle_contributor_activity()
-
         bot.validate_pr_issues.assert_called_once_with(mock_pr)
         mock_pr.remove_from_labels.assert_not_called()
         bot_env["repo"].get_issue.assert_not_called()

--- a/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
+++ b/.github/actions/bot-autoassign/tests/test_pr_reopen_bot.py
@@ -121,6 +121,7 @@ class TestPRReopenBot:
 
     def test_handle_pr_reopen(self, bot_env):
         bot = PRReopenBot()
+        bot.validate_pr_issues = Mock(return_value=True)
         bot.load_event_payload(
             {
                 "pull_request": {
@@ -142,6 +143,27 @@ class TestPRReopenBot:
         assert bot.handle_pr_reopen()
         mock_issue.add_to_assignees.assert_called_once_with("testuser")
 
+    def test_handle_pr_reopen_ignores_invalid_pr(self, bot_env):
+        bot = PRReopenBot()
+        bot.validate_pr_issues = Mock(return_value=False)
+        bot.load_event_payload(
+            {
+                "pull_request": {
+                    "number": 100,
+                    "user": {"login": "testuser"},
+                    "body": "Fixes #123",
+                }
+            }
+        )
+        mock_pr = Mock()
+        bot_env["repo"].get_pull.return_value = mock_pr
+
+        assert bot.handle_pr_reopen()
+
+        bot.validate_pr_issues.assert_called_once_with(mock_pr)
+        bot_env["repo"].get_issue.assert_not_called()
+        mock_pr.remove_from_labels.assert_not_called()
+
     def test_handle_pr_reopen_no_payload(self, bot_env):
         bot = PRReopenBot()
         assert not bot.handle_pr_reopen()
@@ -153,6 +175,12 @@ class TestPRReopenBot:
 
 
 class TestPRActivityBot:
+    @pytest.fixture(autouse=True)
+    def valid_pr(self, monkeypatch):
+        monkeypatch.setattr(
+            PRActivityBot, "validate_pr_issues", Mock(return_value=True)
+        )
+
     def test_handle_contributor_activity(self, bot_env):
         bot = PRActivityBot()
         bot.load_event_payload(
@@ -215,6 +243,29 @@ class TestPRActivityBot:
         mock_pr.remove_from_labels.assert_called_once_with("stale")
         mock_issue.add_to_assignees.assert_called_once_with("nonmember")
         mock_pr.create_issue_comment.assert_not_called()
+
+    def test_handle_contributor_activity_ignores_invalid_pr(self, bot_env):
+        bot = PRActivityBot()
+        bot.validate_pr_issues = Mock(return_value=False)
+        bot.load_event_payload(
+            {
+                "issue": {
+                    "number": 100,
+                    "pull_request": {"url": "https://api.github.com/..."},
+                },
+                "comment": {"user": {"login": "testuser"}},
+            }
+        )
+        mock_pr = Mock()
+        mock_pr.user.login = "testuser"
+        mock_pr.get_labels.return_value = []
+        bot_env["repo"].get_pull.return_value = mock_pr
+
+        assert bot.handle_contributor_activity()
+
+        bot.validate_pr_issues.assert_called_once_with(mock_pr)
+        mock_pr.remove_from_labels.assert_not_called()
+        bot_env["repo"].get_issue.assert_not_called()
 
     def test_handle_contributor_activity_not_author(self, bot_env):
         bot = PRActivityBot()

--- a/.github/workflows/bot-autoassign-issue.yml
+++ b/.github/workflows/bot-autoassign-issue.yml
@@ -14,35 +14,12 @@ concurrency:
 
 jobs:
   respond-to-assign-request:
-    runs-on: ubuntu-latest
     if: >
       github.repository == 'openwisp/openwisp-utils' &&
       github.event.issue.pull_request == null
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e .[github_actions]
-
-      - name: Run issue assignment bot
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          BOT_USERNAME: openwisp-companion
-        run: >
-          python .github/actions/bot-autoassign/__main__.py
-          issue_assignment "$GITHUB_EVENT_PATH"
+    uses: ./.github/workflows/reusable-bot-autoassign.yml
+    with:
+      bot_command: issue_assignment
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-pr-reopen.yml
+++ b/.github/workflows/bot-autoassign-pr-reopen.yml
@@ -17,70 +17,25 @@ concurrency:
 
 jobs:
   reassign-on-reopen:
-    runs-on: ubuntu-latest
     if: >
       github.repository == 'openwisp/openwisp-utils' &&
       github.event_name == 'pull_request_target' &&
       github.event.action == 'reopened'
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e .[github_actions]
-
-      - name: Reassign issues on PR reopen
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: >
-          python .github/actions/bot-autoassign/__main__.py
-          pr_reopen "$GITHUB_EVENT_PATH"
+    uses: ./.github/workflows/reusable-bot-autoassign.yml
+    with:
+      bot_command: pr_reopen
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
 
   handle-pr-activity:
-    runs-on: ubuntu-latest
     if: >
       github.repository == 'openwisp/openwisp-utils' &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e .[github_actions]
-
-      - name: Handle PR activity
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-        # The pr_reopen bot type handles both PR reopen and issue comment (PR activity) events
-        run: >
-          python .github/actions/bot-autoassign/__main__.py
-          pr_reopen "$GITHUB_EVENT_PATH"
+    uses: ./.github/workflows/reusable-bot-autoassign.yml
+    with:
+      bot_command: pr_reopen
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/docs/developer/reusable-github-utils.rst
+++ b/docs/developer/reusable-github-utils.rst
@@ -62,26 +62,29 @@ Auto-Assignment Bot
 A collection of Python scripts that automate issue and PR management for
 OpenWISP repositories. The bot provides the following features:
 
-- **Issue auto-assignment**: When a contributor opens a PR referencing an
-  issue (e.g., ``Fixes #123``), the issue is automatically assigned to the
-  PR author.
+- **Issue auto-assignment**: When a contributor opens a valid PR
+  referencing an issue (e.g., ``Fixes #123``), the issue is automatically
+  assigned to the PR author.
 - **Assignment request responses**: When someone comments asking to be
-  assigned, the bot responds with contributing guidelines explaining that
-  no assignment is needed — just open a PR.
+  assigned, the bot checks whether the issue is validated. For validated
+  issues, it explains that no assignment is needed before opening a PR.
+  For issues that have not been validated, it explains the validation
+  requirements for external contributors.
 - **Stale PR management**: Warns PR authors after 7 days of inactivity,
   marks stale and unassigns after 14 days, and posts a final follow-up
   encouragement after 60 days. The bot does not auto-close stale PRs.
-- **PR reopen reassignment**: When a stale PR is reopened, linked issues
-  are reassigned back to the author.
+- **PR reopen reassignment**: When a valid stale PR is reopened, linked
+  issues are reassigned back to the author.
 - **PR validation**: Enforces the `OpenWISP Contributing Guidelines
   <https://openwisp.io/docs/dev/developer/contributing.html>`_ for
-  external contributors by flagging PRs that do not link a validated
-  issue. PRs created by the configured GitHub App are exempt. The bot
-  removes the ``invalid`` label once the PR is valid and closes unresolved
-  invalid PRs after 24 hours. For valid PRs, it applies the ``ai-review``
-  label, which triggers a CodeRabbit review. The label prevents repeated
-  reviews. Dependabot PRs and PRs whose titles begin with ``[release]`` or
-  ``[backport]`` do not receive the label.
+  external contributors. A :ref:`validated issue
+  <openwisp_look_for_open_issues>` is required. The bot flags PRs that do
+  not link one. PRs created by the configured GitHub App are exempt. The
+  bot removes the ``invalid`` label once the PR is valid and closes
+  unresolved invalid PRs after 24 hours. For valid PRs, it applies the
+  ``ai-review`` label, which triggers a CodeRabbit review. The label
+  prevents repeated reviews. ``Dependabot`` PRs and PRs whose titles begin
+  with ``[release]`` or ``[backport]`` do not receive the label.
 
 **How Stale PR Detection Works**
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A. This reusable automation change has no existing issue.

## Description of Changes

- Validate issue assignment requests before suggesting contribution work.
- Prevent manual, reopened, and stale PR reassignment when the PR is invalid.
- Use the reusable workflow to provide project-aware validation.

## Screenshot

N/A. This change affects GitHub automation only.