### PR TITLE
[tests] Fixed assertNumQueries reporting of failure locations

### DIFF
--- a/openwisp_utils/tests/utils.py
+++ b/openwisp_utils/tests/utils.py
@@ -1,7 +1,7 @@
 import io
 import sys
 from contextlib import contextmanager
-from inspect import signature
+from inspect import currentframe, signature
 from time import time
 from unittest import TextTestResult, mock
 
@@ -143,9 +143,10 @@ class capture_any_output(CaptureOutput):
 class _AssertNumQueriesContextSubTest(CaptureQueriesContext):
     """Needed to execute assertNumQueries in a subTest."""
 
-    def __init__(self, test_case, num, connection):
+    def __init__(self, test_case, num, connection, location):
         self.test_case = test_case
         self.num = num
+        self.location = location
         super().__init__(connection)
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -153,7 +154,9 @@ class _AssertNumQueriesContextSubTest(CaptureQueriesContext):
         if exc_type is not None:
             return
         executed = len(self)
-        with self.test_case.subTest(f"Expecting {self.num} SQL queries"):
+        with self.test_case.subTest(
+            f"Expecting {self.num} SQL queries at {self.location}"
+        ):
             self.test_case.assertEqual(
                 executed,
                 self.num,
@@ -172,8 +175,9 @@ class _AssertNumQueriesContextSubTest(CaptureQueriesContext):
 class AssertNumQueriesSubTestMixin:
     def assertNumQueries(self, num, func=None, *args, using=DEFAULT_DB_ALIAS, **kwargs):
         conn = connections[using]
-
-        context = _AssertNumQueriesContextSubTest(self, num, conn)
+        caller = currentframe().f_back
+        location = f"{caller.f_code.co_filename}:{caller.f_lineno}"
+        context = _AssertNumQueriesContextSubTest(self, num, conn, location)
         if func is None:
             return context
 

--- a/tests/test_project/tests/test_test_utils.py
+++ b/tests/test_project/tests/test_test_utils.py
@@ -1,5 +1,7 @@
 import io
+import re
 import sys
+from contextlib import nullcontext
 from unittest.mock import patch
 
 from django.dispatch import Signal
@@ -212,3 +214,15 @@ class TestAssertNumQueriesSubTest(AssertNumQueriesSubTestMixin, TestCase):
             with self.assertNumQueries(1):
                 Shelf.objects.count()
             patched_subtest.assert_called_once()
+
+    def test_assert_num_queries_failure_includes_call_site(self):
+        with patch.object(
+            self, "subTest", return_value=nullcontext()
+        ) as patched_subtest:
+            with self.assertRaises(AssertionError):
+                with self.assertNumQueries(1):
+                    pass
+        self.assertRegex(
+            patched_subtest.call_args.args[0],
+            rf"^Expecting 1 SQL queries at {re.escape(__file__)}:\d+$",
+        )


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Improved the diagnostic output of `AssertNumQueriesSubTestMixin` so that query-count failures now include the file and line of the calling `assertNumQueries()` statement. This makes it easier to locate the failing test code when the assertion is raised from the shared helper in `openwisp_utils/tests/utils.py`.

## Screenshot

N/A