### PR TITLE
[chores] Releaser: stripped `[backport]` markers from change log

### DIFF
--- a/docs/developer/releaser-tool.rst
+++ b/docs/developer/releaser-tool.rst
@@ -73,8 +73,10 @@ different version manually.
 
 **2. Change Log Generation & Review** A changelog is generated from your
 recent commits. Entries include commit bodies but omit Git trailers and
-issue-reference footers. You will be shown the final changelog block and
-asked to accept it before the files are modified.
+issue-reference footers. Backport markers in the format ``[backport
+<version>]`` are removed, and entries containing only a backport marker
+are discarded. You will be shown the final changelog block and asked to
+accept it before the files are modified.
 
 **3. Resilient Error Handling** If any network operation fails (e.g.,
 creating a pull request), the tool won't crash. Instead, it will prompt

--- a/openwisp_utils/releaser/changelog.py
+++ b/openwisp_utils/releaser/changelog.py
@@ -111,7 +111,7 @@ def _clean_commit_metadata(lines):
             line = line.rstrip()
         is_body_line = line.strip().startswith(CHANGELOG_BODY_MARKER)
         stripped_line = _get_changelog_line_content(line)
-        if backport_marker_count and not stripped_line:
+        if backport_marker_count and stripped_line in ("", "-"):
             continue
         if skip_dependabot_metadata:
             if stripped_line == "...":

--- a/openwisp_utils/releaser/changelog.py
+++ b/openwisp_utils/releaser/changelog.py
@@ -107,7 +107,8 @@ def _clean_commit_metadata(lines):
     )
     for index, line in enumerate(lines):
         line, backport_marker_count = BACKPORT_MARKER_PATTERN.subn("", line)
-        line = line.rstrip()
+        if backport_marker_count:
+            line = line.rstrip()
         is_body_line = line.strip().startswith(CHANGELOG_BODY_MARKER)
         stripped_line = _get_changelog_line_content(line)
         if backport_marker_count and not stripped_line:

--- a/openwisp_utils/releaser/changelog.py
+++ b/openwisp_utils/releaser/changelog.py
@@ -11,6 +11,7 @@ from .constants import ISSUE_REFERENCE_KEYWORDS
 from .utils import _call_docstrfmt
 
 CHANGELOG_BODY_MARKER = "OW_CHANGELOG_BODY:"
+BACKPORT_MARKER_PATTERN = re.compile(r"\s*\[backport\s+\d+(?:\.\d+)*\]")
 
 
 def _get_changelog_line_content(line):
@@ -105,8 +106,12 @@ def _clean_commit_metadata(lines):
         re.IGNORECASE,
     )
     for index, line in enumerate(lines):
+        line, backport_marker_count = BACKPORT_MARKER_PATTERN.subn("", line)
+        line = line.rstrip()
         is_body_line = line.strip().startswith(CHANGELOG_BODY_MARKER)
         stripped_line = _get_changelog_line_content(line)
+        if backport_marker_count and not stripped_line:
+            continue
         if skip_dependabot_metadata:
             if stripped_line == "...":
                 skip_dependabot_metadata = False

--- a/openwisp_utils/releaser/tests/test_changelog.py
+++ b/openwisp_utils/releaser/tests/test_changelog.py
@@ -302,11 +302,13 @@ def test_process_changelog_strips_backport_markers():
     changelog_text = """Changes
 ~~~~~~~
 - Changed changelog formatting [backport 1.2]
+- [backport 1.2.3]
 
 OW_CHANGELOG_BODY:Applied the fix [backport 1.2.3.4]
 OW_CHANGELOG_BODY:  [backport 1.2.3.4]""" + "  \n"
     processed_text = process_changelog(changelog_text)
     assert "[backport" not in processed_text
+    assert "-" not in processed_text.splitlines()
     assert "- Changed changelog formatting" in processed_text
     assert "  Applied the fix" in processed_text
 

--- a/openwisp_utils/releaser/tests/test_changelog.py
+++ b/openwisp_utils/releaser/tests/test_changelog.py
@@ -298,13 +298,13 @@ OW_CHANGELOG_BODY:{keyword} `#123 <https://github.com/#REPO#/issues/123>`_
 
 
 def test_process_changelog_strips_backport_markers():
+    # extra white-space is intentional
     changelog_text = """Changes
 ~~~~~~~
 - Changed changelog formatting [backport 1.2]
 
 OW_CHANGELOG_BODY:Applied the fix [backport 1.2.3.4]
-OW_CHANGELOG_BODY:[backport 1.2.3.4]
-"""
+OW_CHANGELOG_BODY:  [backport 1.2.3.4]""" + "  \n"
     processed_text = process_changelog(changelog_text)
     assert "[backport" not in processed_text
     assert "- Changed changelog formatting" in processed_text

--- a/openwisp_utils/releaser/tests/test_changelog.py
+++ b/openwisp_utils/releaser/tests/test_changelog.py
@@ -297,6 +297,20 @@ OW_CHANGELOG_BODY:{keyword} `#123 <https://github.com/#REPO#/issues/123>`_
     assert f"{keyword} `#123" not in processed_text
 
 
+def test_process_changelog_strips_backport_markers():
+    changelog_text = """Changes
+~~~~~~~
+- Changed changelog formatting [backport 1.2]
+
+OW_CHANGELOG_BODY:Applied the fix [backport 1.2.3.4]
+OW_CHANGELOG_BODY:[backport 1.2.3.4]
+"""
+    processed_text = process_changelog(changelog_text)
+    assert "[backport" not in processed_text
+    assert "- Changed changelog formatting" in processed_text
+    assert "  Applied the fix" in processed_text
+
+
 def test_process_changelog_preserves_markdown_links_for_markdown_output():
     changelog_text = """Dependencies
 ++++++++++++


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Strips bracketed backport markers with dot-separated versions from generated changelog entries and removes marker-only lines.

## Screenshot

N/A