### PR TITLE
[chores:fix] Releaser: fixed change-log for old stable releases

### DIFF
--- a/docs/developer/releaser-tool.rst
+++ b/docs/developer/releaser-tool.rst
@@ -76,7 +76,8 @@ recent commits. Entries include commit bodies but omit Git trailers and
 issue-reference footers. Backport markers in the format ``[backport
 <version>]`` are removed, and entries containing only a backport marker
 are discarded. You will be shown the final changelog block and asked to
-accept it before the files are modified.
+asked to accept it before the files are modified. On an old stable branch,
+only tags reachable from that branch determine the changelog range.
 
 **3. Resilient Error Handling** If any network operation fails (e.g.,
 creating a pull request), the tool won't crash. Instead, it will prompt
@@ -101,7 +102,7 @@ process:
 6. Once merged, it creates and pushes a signed git tag.
 7. Finally, it creates a draft release on GitHub with the changelog notes.
 8. If releasing a bugfix, it offers to port the changelog to the ``main``
-   or ``master`` branch.
+   or ``master`` branch, maintaining descending release-version order.
 
 GitHub release descriptions are normalized without paragraph wrapping
 before submission. This does not modify the changelog file.

--- a/openwisp_utils/releaser/changelog.py
+++ b/openwisp_utils/releaser/changelog.py
@@ -386,19 +386,24 @@ def update_changelog_file(changelog_path, new_block, is_port=False):
         # For a bugfix port, insert the new block before the first lower release version.
         version_header_regex = re.compile(
             (
-                r"^##\s+(?:Version\s+)?(\d+)\.(\d+)\.(\d+)"
+                r"^##\s+(?:Version\s+)?(\d+)\.(\d+)\.(\d+)[^\n]*"
                 if is_md
-                else r"^(?:Version\s+)?(\d+)\.(\d+)\.(\d+)"
+                else r"^(?:Version\s+)?(\d+)\.(\d+)\.(\d+)[^\n]*"
             ),
             re.MULTILINE,
         )
         version_match = version_header_regex.search(new_block)
         if version_match:
             version = tuple(map(int, version_match.groups()))
+            release_matches = [
+                match
+                for match in version_header_regex.finditer(content)
+                if "[unreleased]" not in match.group().lower()
+            ]
             insertion_point = next(
                 (
                     match.start()
-                    for match in version_header_regex.finditer(content)
+                    for match in release_matches
                     if tuple(map(int, match.groups())) < version
                 ),
                 len(content),

--- a/openwisp_utils/releaser/changelog.py
+++ b/openwisp_utils/releaser/changelog.py
@@ -52,7 +52,7 @@ def find_cliff_config():
 
 
 def run_git_cliff(version=None):
-    """Runs the 'git cliff --unreleased' command and returns its output."""
+    """Runs git-cliff for untagged commits on the current branch."""
     config_path = find_cliff_config()
     if not config_path:
         print(
@@ -72,7 +72,14 @@ def run_git_cliff(version=None):
         print(f"Warning: Failed to pull tags: {e.stderr}", file=sys.stderr)
     # Run git-cliff to calculate changelog
     try:
-        cmd = ["git", "cliff", "--unreleased", "--config", config_path]
+        cmd = [
+            "git",
+            "cliff",
+            "--unreleased",
+            "--use-branch-tags",
+            "--config",
+            config_path,
+        ]
         if version:
             cmd.extend(["--tag", version])
 
@@ -345,7 +352,7 @@ def get_release_block_from_file(config, version):
 def update_changelog_file(changelog_path, new_block, is_port=False):
     # Updates the changelog file for all release types.
     # - For a feature release, it replaces the entire [Unreleased] section with the new content.
-    # - For a ported bugfix, it inserts the new block after the [Unreleased] section.
+    # - For a ported bugfix, it inserts the new block in descending version order.
 
     is_md = changelog_path.endswith(".md")
     try:
@@ -376,14 +383,34 @@ def update_changelog_file(changelog_path, new_block, is_port=False):
         lines.insert(header_end_index, new_block.strip() + "\n\n")
         new_content = "".join(lines)
     elif is_port:
-        # For a bugfix port, insert the new block AFTER the [Unreleased] block.
-        insertion_point = unreleased_match.end()
+        # For a bugfix port, insert the new block before the first lower release version.
+        version_header_regex = re.compile(
+            (
+                r"^##\s+(?:Version\s+)?(\d+)\.(\d+)\.(\d+)"
+                if is_md
+                else r"^(?:Version\s+)?(\d+)\.(\d+)\.(\d+)"
+            ),
+            re.MULTILINE,
+        )
+        version_match = version_header_regex.search(new_block)
+        if version_match:
+            version = tuple(map(int, version_match.groups()))
+            insertion_point = next(
+                (
+                    match.start()
+                    for match in version_header_regex.finditer(content)
+                    if tuple(map(int, match.groups())) < version
+                ),
+                len(content),
+            )
+        else:
+            insertion_point = unreleased_match.end()
         new_content = (
             content[:insertion_point].rstrip()
             + "\n\n"
             + new_block.strip()
-            + "\n"
-            + content[insertion_point:]
+            + "\n\n"
+            + content[insertion_point:].lstrip()
         )
     else:
         # For a feature release, REPLACE the entire [Unreleased] block.

--- a/openwisp_utils/releaser/tests/test_changelog.py
+++ b/openwisp_utils/releaser/tests/test_changelog.py
@@ -80,13 +80,13 @@ def git_repo():
     shutil.rmtree(test_dir)
 
 
-def _run_git_cliff_with_expected_warning():
+def _run_git_cliff_with_expected_warning(version=None):
     raw_changelog = None
 
     @capture_stderr()
     def _run(captured_error):
         nonlocal raw_changelog
-        raw_changelog = run_git_cliff()
+        raw_changelog = run_git_cliff(version=version)
         assert captured_error.getvalue().startswith("Warning: Failed to pull tags:")
 
     _run()
@@ -187,6 +187,39 @@ Co-authored-by: Test User <test@example.com>
     assert "cherry picked from commit" not in actual_output
     assert "Signed-off-by:" not in actual_output
     assert "Co-authored-by:" not in actual_output
+
+
+def test_changelog_generation_for_old_stable_branch_uses_latest_branch_tag(git_repo):
+    """Tests that releases on old stable branches exclude prior stable releases."""
+
+    def _git_commit(message):
+        filename = f"{message.replace(' ', '_')}.txt"
+        with open(filename, "w") as f:
+            f.write(message)
+        subprocess.run(["git", "add", filename], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", message], check=True, capture_output=True
+        )
+
+    _git_commit("[fix] Fixed initial 1.2 release")
+    subprocess.run(["git", "tag", "1.2.0"], check=True, capture_output=True)
+    subprocess.run(["git", "branch", "1.2"], check=True, capture_output=True)
+    _git_commit("[fix] Fixed 1.3 release")
+    subprocess.run(["git", "tag", "1.3.0"], check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "1.2"], check=True, capture_output=True)
+    _git_commit("[fix] Fixed 1.2.1 release")
+    subprocess.run(["git", "tag", "1.2.1"], check=True, capture_output=True)
+    _git_commit("[fix] Fixed 1.2.2 release")
+    subprocess.run(["git", "tag", "1.2.2"], check=True, capture_output=True)
+    _git_commit("[fix] Fixed expected 1.2.3 release")
+    raw_changelog = _run_git_cliff_with_expected_warning(version="1.2.3")
+    assert "Fixed expected 1.2.3 release" in raw_changelog
+    assert (
+        "Fixed 1.2.2 release" not in raw_changelog
+    ), "The changelog must include only commits newer than the latest 1.2 tag."
+    assert (
+        "Fixed 1.2.1 release" not in raw_changelog
+    ), "The changelog must include only commits newer than the latest 1.2 tag."
 
 
 def test_changelog_generation_excludes_dependabot_metadata_block(git_repo):
@@ -509,6 +542,50 @@ def test_update_changelog_bugfix_port_flow(mock_file):
     )
 
 
+@pytest.mark.parametrize(
+    ("changelog_path", "header", "suffix"),
+    (
+        ("CHANGES.rst", "Version ", "\n--------------------------"),
+        ("CHANGES.md", "## Version ", ""),
+    ),
+)
+def test_update_changelog_bugfix_port_uses_release_version_order(
+    changelog_path, header, suffix
+):
+    """Tests that a ported bugfix is placed with its stable-version series."""
+    changelog = f"""Changelog
+=========
+
+{header}1.4.0 [Unreleased]{suffix}
+
+Work in progress.
+
+{header}1.3.1 [2026-09-10]{suffix}
+
+- A 1.3 fix.
+
+{header}1.2.2 [2026-09-09]{suffix}
+
+- A 1.2 fix.
+"""
+    new_block = f"""{header}1.2.3 [2026-09-11]{suffix}
+
+Bugfixes
+~~~~~~~~
+
+- Prevented SMS verification bypasses
+"""
+    with patch("builtins.open", mock_open(read_data=changelog)) as mock_file:
+        update_changelog_file(changelog_path, new_block, is_port=True)
+    written_content = mock_file().write.call_args[0][0]
+    assert new_block in written_content
+    assert (
+        written_content.index(f"{header}1.3.1")
+        < written_content.index(f"{header}1.2.3")
+        < written_content.index(f"{header}1.2.2")
+    ), "A ported release must be inserted above its previous stable release."
+
+
 @patch("builtins.open", new_callable=mock_open, read_data=SAMPLE_CHANGELOG)
 def test_update_changelog_feature_flow(mock_file):
     """Test that a feature release REPLACES the unreleased block."""
@@ -568,6 +645,7 @@ def test_run_git_cliff_calls_git_pull_tags(mock_subprocess_run, mock_find_config
         "git" in second_call_args
         and "cliff" in second_call_args
         and "--unreleased" in second_call_args
+        and "--use-branch-tags" in second_call_args
     )
 
 

--- a/openwisp_utils/releaser/tests/test_changelog.py
+++ b/openwisp_utils/releaser/tests/test_changelog.py
@@ -543,14 +543,37 @@ def test_update_changelog_bugfix_port_flow(mock_file):
 
 
 @pytest.mark.parametrize(
-    ("changelog_path", "header", "suffix"),
+    ("changelog_path", "header", "suffix", "version", "preceding", "following"),
     (
-        ("CHANGES.rst", "Version ", "\n--------------------------"),
-        ("CHANGES.md", "## Version ", ""),
+        (
+            "CHANGES.rst",
+            "Version ",
+            "\n--------------------------",
+            "1.2.3",
+            "1.3.1",
+            "1.2.2",
+        ),
+        ("CHANGES.md", "## Version ", "", "1.2.3", "1.3.1", "1.2.2"),
+        (
+            "CHANGES.rst",
+            "Version ",
+            "\n--------------------------",
+            "1.4.1",
+            "1.4.0 [Unreleased]",
+            "1.3.1",
+        ),
+        (
+            "CHANGES.md",
+            "## Version ",
+            "",
+            "1.4.1",
+            "1.4.0 [Unreleased]",
+            "1.3.1",
+        ),
     ),
 )
 def test_update_changelog_bugfix_port_uses_release_version_order(
-    changelog_path, header, suffix
+    changelog_path, header, suffix, version, preceding, following
 ):
     """Tests that a ported bugfix is placed with its stable-version series."""
     changelog = f"""Changelog
@@ -568,7 +591,7 @@ Work in progress.
 
 - A 1.2 fix.
 """
-    new_block = f"""{header}1.2.3 [2026-09-11]{suffix}
+    new_block = f"""{header}{version} [2026-09-11]{suffix}
 
 Bugfixes
 ~~~~~~~~
@@ -580,9 +603,9 @@ Bugfixes
     written_content = mock_file().write.call_args[0][0]
     assert new_block in written_content
     assert (
-        written_content.index(f"{header}1.3.1")
-        < written_content.index(f"{header}1.2.3")
-        < written_content.index(f"{header}1.2.2")
+        written_content.index(f"{header}{preceding}")
+        < written_content.index(f"{header}{version}")
+        < written_content.index(f"{header}{following}")
     ), "A ported release must be inserted above its previous stable release."
 
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [ ] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

- Uses branch-scoped tags when generating a release changelog, preventing old stable releases from including prior tagged entries.
- Inserts ported bugfix changelog blocks in descending release-version order.
- Adds regression coverage for old stable branches and RST and Markdown changelog ports.

Manual verification is pending. To perform it, create a test old stable branch with prior tags and a newer release series on main, then verify the generated and ported changelog blocks.

## Screenshot

N/A